### PR TITLE
Allow custom steps on a test build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,3 +40,8 @@ jobs:
     - name: tk-multi-testing
       ref: azure_test_branch
     - name: tk-framework-qtwidgets
+    # This one shouldn't get cloned.
+    - name: tk-ci-tools
+    post_tests_steps:
+    - bash: echo "Hello from the first post step!"
+    - bash: echo "Hello from the second post step!"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,4 +44,6 @@ jobs:
     - name: tk-ci-tools
     post_tests_steps:
     - bash: echo "Hello from the first post step!"
+      displayName: Hello world!
     - bash: echo "Hello from the second post step!"
+      displayName: Hello again!

--- a/build-pipeline.yml
+++ b/build-pipeline.yml
@@ -27,6 +27,15 @@ parameters:
   tk_core_ref: SG-13264-python-3-compat
   # Allows to skip test execution.
   skip_tests: false
+  # Post test steps
+  # This is a list of Azure Pipeline steps that will be inserted
+  # right after the tests were run.
+  # If you wanted to run a non-standard suite of test as an extra
+  # you would specify post_tests_steps as:
+  # post_tests_steps:
+  # - bash: do_something
+  # - bash: do_something_else
+  post_tests_steps: []
 
 # This build pipeline will validate the code style and our test suite on
 # multiple platforms.

--- a/internal/clone-repositories.yml
+++ b/internal/clone-repositories.yml
@@ -23,4 +23,4 @@ steps:
    - bash: git clone --depth 1 --branch ${{ coalesce(repo.ref, 'master') }} https://github.com/shotgunsoftware/${{ repo.name }} ../${{ repo.name }}
      displayName: Clone ${{ repo.name }}(${{ coalesce(repo.ref, 'master') }})
      # Allows us to easily skip when cloning tk-core inside the tk-core repo.
-     condition: and(succeeded(), ne(variables["Build.DefinitionName"], "${{ repo.name }}"))
+     condition: ne(variables["Build.DefinitionName"], "${{ repo.name }}")

--- a/internal/clone-repositories.yml
+++ b/internal/clone-repositories.yml
@@ -23,4 +23,4 @@ steps:
    - bash: git clone --depth 1 --branch ${{ coalesce(repo.ref, 'master') }} https://github.com/shotgunsoftware/${{ repo.name }} ../${{ repo.name }}
      displayName: Clone ${{ repo.name }}(${{ coalesce(repo.ref, 'master') }})
      # Allows us to easily skip when cloning tk-core inside the tk-core repo.
-     condition: ne(variables["Build.DefinitionName"], "${{ repo.name }}")
+     condition: ne(variables['Build.DefinitionName'], '${{ repo.name }}')

--- a/internal/clone-repositories.yml
+++ b/internal/clone-repositories.yml
@@ -23,4 +23,4 @@ steps:
    - bash: git clone --depth 1 --branch ${{ coalesce(repo.ref, 'master') }} https://github.com/shotgunsoftware/${{ repo.name }} ../${{ repo.name }}
      displayName: Clone ${{ repo.name }}(${{ coalesce(repo.ref, 'master') }})
      # Allows us to easily skip when cloning tk-core inside the tk-core repo.
-     condition: ne($(Build.DefinitionName), "${{ repo.name }}")
+     condition: and(succeeded(), ne(variables["Build.DefinitionName"], "${{ repo.name }}"))

--- a/internal/clone-repositories.yml
+++ b/internal/clone-repositories.yml
@@ -22,3 +22,5 @@ steps:
 - ${{ each repo in parameters.repositories }}:
    - bash: git clone --depth 1 --branch ${{ coalesce(repo.ref, 'master') }} https://github.com/shotgunsoftware/${{ repo.name }} ../${{ repo.name }}
      displayName: Clone ${{ repo.name }}(${{ coalesce(repo.ref, 'master') }})
+     # Allows us to easily skip when cloning tk-core inside the tk-core repo.
+     condition: ne($(Build.DefinitionName), "${{ repo.name }}")

--- a/internal/code-style-validation.yml
+++ b/internal/code-style-validation.yml
@@ -35,11 +35,14 @@ jobs:
       - pre-commit
       - git+https://github.com/shotgunsoftware/tk-toolchain.git@${{ parameters.tk_toolchain_ref }}#egg=tk-toolchain
 
+
+
   - template: clone-repositories.yml
     parameters:
       repositories:
       - name: tk-core
         ref: ${{ parameters.tk_core_ref }}
+
 
   - bash: pre-commit run --all
     displayName: Validate code

--- a/internal/code-style-validation.yml
+++ b/internal/code-style-validation.yml
@@ -35,14 +35,11 @@ jobs:
       - pre-commit
       - git+https://github.com/shotgunsoftware/tk-toolchain.git@${{ parameters.tk_toolchain_ref }}#egg=tk-toolchain
 
-
-
   - template: clone-repositories.yml
     parameters:
       repositories:
       - name: tk-core
         ref: ${{ parameters.tk_core_ref }}
-
 
   - bash: pre-commit run --all
     displayName: Validate code

--- a/internal/unit-tests-with.yml
+++ b/internal/unit-tests-with.yml
@@ -31,7 +31,14 @@ parameters:
   additional_repositories: []
   # Git ref of tk-core to use.
   tk_core_ref: master
-  # List of steps to execute after the tests were run.
+  # Post test steps
+  # This is a list of Azure Pipeline steps that will be inserted
+  # right after the tests were run.
+  # If you wanted to run a non-standard suite of test as an extra
+  # you would specify post_tests_steps as:
+  # post_tests_steps:
+  # - bash: do_something
+  # - bash: do_something_else
   post_tests_steps: []
 
 jobs:
@@ -83,6 +90,8 @@ jobs:
 
   # Run the tests. The task will create a simple coverage file if one is missing.
   # It will include all code except for the "tests" folder.
+  # Note that we're hardcoding the name of the coverage file. This is important
+  # as "coverage combine" will combine all coverage files that match .coverage.*.
   - bash: |
       (test -e .coveragerc && echo ".coveragerc was found." ) || ((python -c "print('[run]\nsource=.\nomit=\n    tests/*\n[report]\n\nexclude_lines =\n    raise NotImplementedError')" > .coveragerc) && echo "Generated .coveragerc")
       COVERAGE_FILE=.coverage.tests python -m pytest tests --cov --verbose
@@ -95,8 +104,11 @@ jobs:
       TK_DEBUG: 1
     displayName: Run tests
 
+  # The post_test_steps list will be flattened into this list of steps.
   - ${{ parameters.post_tests_steps }}
 
+  # We're done, we can now upload code coverage, but first, we'll have to
+  # combine the results.
   - bash: |
       python -m coverage combine
       curl -s https://codecov.io/bash > codecov.sh

--- a/internal/unit-tests-with.yml
+++ b/internal/unit-tests-with.yml
@@ -31,6 +31,8 @@ parameters:
   additional_repositories: []
   # Git ref of tk-core to use.
   tk_core_ref: master
+  # List of steps to execute after the tests were run.
+  post_tests_steps: []
 
 jobs:
 - job:
@@ -83,7 +85,7 @@ jobs:
   # It will include all code except for the "tests" folder.
   - bash: |
       (test -e .coveragerc && echo ".coveragerc was found." ) || ((python -c "print('[run]\nsource=.\nomit=\n    tests/*\n[report]\n\nexclude_lines =\n    raise NotImplementedError')" > .coveragerc) && echo "Generated .coveragerc")
-      python -m pytest tests --cov --verbose
+      COVERAGE_FILE=.coverage.tests python -m pytest tests --cov --verbose
     # These environment variables need to be set so Linux runs can connect
     # to xvfb and to have complete logging. Each test logging output will
     # be captured by pytest and displayed on failure.
@@ -93,7 +95,10 @@ jobs:
       TK_DEBUG: 1
     displayName: Run tests
 
+  - ${{ parameters.post_tests_steps }}
+
   - bash: |
+      python -m coverage combine
       curl -s https://codecov.io/bash > codecov.sh
       bash codecov.sh
     displayName: Upload code coverage

--- a/internal/unit-tests.yml
+++ b/internal/unit-tests.yml
@@ -23,6 +23,15 @@ parameters:
   additional_repositories: []
   # Git ref of tk-core to use.
   tk_core_ref: master
+  # Post test steps
+  # This is a list of Azure Pipeline steps that will be inserted
+  # right after the tests were run.
+  # If you wanted to run a non-standard suite of test as an extra
+  # you would specify post_tests_steps as:
+  # post_tests_steps:
+  # - bash: do_something
+  # - bash: do_something_else
+  post_tests_steps: []
 
 # TODO: At some point, we should review how these environments are enumerated.
 # Something like:


### PR DESCRIPTION
This very simple feature allows a user to add any number of steps after tests have executed during a job. This is used by the tk-core repo in order to run integration tests that talk to a real Shotgun site.

I've also fixed the clone template so that a repository doesn't attempt to clone itself. This happened with tk-core, as the pipeline will always try to clone that repository.