### PR TITLE
Uploading media and archives to S3 during AppStore upload

### DIFF
--- a/internal/release-to-appstore.yml
+++ b/internal/release-to-appstore.yml
@@ -35,9 +35,9 @@ steps:
     '`
     if [ $(Build.DefinitionName) = tk-core ]
     then
-        python ../release_scripts/app_store/core_to_app_store.py --no-ftp --tag $(Build.SourceBranchName)
+        python ../release_scripts/app_store/core_to_app_store.py --tag $(Build.SourceBranchName)
     else
-        python ../release_scripts/app_store/bundle_to_app_store.py --repository $(Build.DefinitionName) --bundle-type $BUNDLE_TYPE --no-ftp --tag $(Build.SourceBranchName)
+        python ../release_scripts/app_store/bundle_to_app_store.py --repository $(Build.DefinitionName) --bundle-type $BUNDLE_TYPE --tag $(Build.SourceBranchName)
     fi
 
   env:


### PR DESCRIPTION
We should always be uploading media or we won't be able to generate the documentation.