### PR TITLE
Allows to use a branch from the release repo.

### DIFF
--- a/build-pipeline.yml
+++ b/build-pipeline.yml
@@ -36,6 +36,11 @@ parameters:
   # - bash: do_something
   # - bash: do_something_else
   post_tests_steps: []
+  # Version of the release repository to use.
+  # This is meant for deployment to the Toolkit AppStore. This repository is private
+  # to the Shotgun team and cannot be accessed by external organizations. This is meant
+  # for internal use by the team for testing and should not be modified otherwise.
+  release_repo_ref: master
 
 # This build pipeline will validate the code style and our test suite on
 # multiple platforms.
@@ -69,3 +74,4 @@ jobs:
     - template: "internal/release.yml"
       parameters:
         tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+        release_repo_ref: ${{ parameters.release_repo_ref }}

--- a/internal/release-to-appstore.yml
+++ b/internal/release-to-appstore.yml
@@ -8,10 +8,13 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+parameters:
+    release_repo_ref: master
+
 steps:
 # Install the release scripts
 - bash: |
-    git clone --depth 1 git@github.com:$RELEASE_REPO ../release_scripts
+    git clone --depth 1 git@github.com:$RELEASE_REPO --branch ${{ parameters.release_repo_ref }}  ../release_scripts
     pip install -r ../release_scripts/app_store/requirements.txt
   env:
     RELEASE_REPO: $(release.repo)

--- a/internal/release.yml
+++ b/internal/release.yml
@@ -11,6 +11,11 @@
 parameters:
   # Version of tk-toolchain to use.
   tk_toolchain_ref: master
+  # Version of the release repository to use.
+  # This is meant for deployment to the Toolkit AppStore. This repository is private
+  # to the Shotgun team and cannot be accessed by external organizations. This is meant
+  # for internal use by the team for testing and should not be modified otherwise.
+  release_repo_ref: ${{ parameters.release_repo_ref }}
 
 jobs:
   # Launch a Linux VM
@@ -54,6 +59,8 @@ jobs:
 
     # Pushes the bundle to the appstore.
     - template: release-to-appstore.yml
+      parameters:
+        release_repo_ref: ${{ parameters.release_repo_ref }}
 
     # We need tk-toolchain to use update-configurations.yml
     # Note that we have to run this after release-to-appstore. Running that

--- a/internal/release.yml
+++ b/internal/release.yml
@@ -15,7 +15,7 @@ parameters:
   # This is meant for deployment to the Toolkit AppStore. This repository is private
   # to the Shotgun team and cannot be accessed by external organizations. This is meant
   # for internal use by the team for testing and should not be modified otherwise.
-  release_repo_ref: ${{ parameters.release_repo_ref }}
+  release_repo_ref: master
 
 jobs:
   # Launch a Linux VM


### PR DESCRIPTION
We need to be able to try out upcoming features from the appstore release scripts, so we can now specify which branch to get them from.