### PR TITLE
macOS image update

### DIFF
--- a/internal/release.yml
+++ b/internal/release.yml
@@ -22,7 +22,7 @@ jobs:
 - job: release_toolkit_bundle
   displayName: Release Toolkit bundle
   pool:
-    vmImage: 'macos-10.13'
+    vmImage: 'macos-10.14'
   steps:
     # This task can be executed only from the "shotgunsoftware"
     # organization repositories. It will fail on forks of our

--- a/internal/unit-tests.yml
+++ b/internal/unit-tests.yml
@@ -85,7 +85,7 @@ jobs:
 # macOS Python 2.7 build
 - template: unit-tests-with.yml
   parameters:
-    image_name: 'macos-10.13'
+    image_name: 'macos-10.14'
     qt_wrapper: PySide2
     python_version: 2.7
     job_name: "macOS Python 2.7"
@@ -95,7 +95,7 @@ jobs:
 # macOS Python 3.7 build
 - template: unit-tests-with.yml
   parameters:
-    image_name: 'macos-10.13'
+    image_name: 'macos-10.14'
     qt_wrapper: PySide2
     python_version: 3.7
     job_name: "macOS Python 3.7"


### PR DESCRIPTION
Microsoft has deprecated macOS 10.13 images and we should move to the 10.14.