### PR TITLE
Fixes an issue with dependency management in pip

### DIFF
--- a/internal/pip-install-packages.yml
+++ b/internal/pip-install-packages.yml
@@ -14,5 +14,5 @@ parameters:
 
 steps:
 - ${{ each package in parameters.packages }}:
-   - bash: pip install ${{ package }}
+   - bash: pip install ${{ package }} --use-feature=2020-resolver
      displayName: Install Python package ${{ package }}

--- a/internal/release-to-appstore.yml
+++ b/internal/release-to-appstore.yml
@@ -15,7 +15,7 @@ steps:
 # Install the release scripts
 - bash: |
     git clone --depth 1 git@github.com:$RELEASE_REPO --branch ${{ parameters.release_repo_ref }}  ../release_scripts
-    pip install -r ../release_scripts/app_store/requirements.txt
+    pip install -r ../release_scripts/app_store/requirements.txt --use-feature=2020-resolver
   env:
     RELEASE_REPO: $(release.repo)
   displayName: Prepare release script


### PR DESCRIPTION
Pip has introduced a new dependency management, which will go live in November. Unfortunately one of our dependencies seems to have a requirement on that new system, so we installed the wrong versions of certain dependencies of tk-toolchain. We are now forcing this new dependency management so tk-toolchain can be installed correctly.