### PR TITLE
Adding SHOTGUN_TEST_ENTITY_SUFFIX env var

### DIFF
--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -137,6 +137,7 @@ jobs:
       TK_TOOLCHAIN_HOST: $(sg.ci.host)
       TK_TOOLCHAIN_USER_LOGIN: $(sg.ci.human.login)
       TK_TOOLCHAIN_USER_PASSWORD: $(sg.ci.human.password)
+      SHOTGUN_TEST_ENTITY_SUFFIX: '$(Agent.Name)'
     displayName: Run tests
 
   # The post_test_steps list will be flattened into this list of steps.


### PR DESCRIPTION
Adding SHOTGUN_TEST_ENTITY_SUFFIX: '$(Agent.Name)' env var to provide a nice way to get Projects unique name in different Toolkit UI automation tests.