### PR TITLE
CI tools to run the appstore release in Python 3.

### DIFF
--- a/internal/release-to-appstore.yml
+++ b/internal/release-to-appstore.yml
@@ -13,6 +13,8 @@ parameters:
 
 steps:
 # Install the release scripts
+# We don't need to call tk-internal's prepare_repo.sh since we will be stating with a fresh environment each time
+# which is setup by Azure. So just clone the repo and install the requirements.
 - bash: |
     git clone --depth 1 git@github.com:$RELEASE_REPO --branch ${{ parameters.release_repo_ref }}  ../release_scripts
     pip install -r ../release_scripts/app_store/requirements.txt --use-feature=2020-resolver

--- a/internal/release-to-appstore.yml
+++ b/internal/release-to-appstore.yml
@@ -13,7 +13,7 @@ parameters:
 
 steps:
 # Install the release scripts
-# We don't need to call tk-internal's prepare_repo.sh since we will be stating with a fresh environment each time
+# We don't need to call the internal script's prepare_repo.sh since we will be stating with a fresh environment each time
 # which is setup by Azure. So just clone the repo and install the requirements.
 - bash: |
     git clone --depth 1 git@github.com:$RELEASE_REPO --branch ${{ parameters.release_repo_ref }}  ../release_scripts

--- a/internal/release.yml
+++ b/internal/release.yml
@@ -29,8 +29,8 @@ jobs:
     # Switch to the right Python Version.
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: 2.7
-      displayName: Use Python 2.7
+        versionSpec: 3.7
+      displayName: Use Python 3.7
 
     # Pushes the bundle to the appstore.
     - template: release-to-appstore.yml


### PR DESCRIPTION
This is dependant on our internal tools being Python 3 ready.