### PR TITLE
SG-24238 Add Python 3.9 Coverage To Azure Pipelines-Tests

### DIFF
--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -175,22 +175,22 @@ jobs:
       has_ui_tests: false
       has_unit_tests: ${{ parameters.has_unit_tests }}
 
-#  # macOS Python 3.9 build
-#  - template: run-tests-with.yml
-#    parameters:
-#      image_name: 'macos-10.15'
-#      qt_wrapper: PySide2==5.14.1
-#      python_version: 3.9
-#      job_name: "macOS Python 3.9"
-#      # pass through all parameters.
-#      extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-#      tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-#      additional_repositories: ${{ parameters.additional_repositories }}
-#      tk_core_ref: ${{ parameters.tk_core_ref }}
-#      post_tests_steps: ${{ parameters.post_tests_steps }}
-#      # Force UI tests off for platforms that don't support them yet.
-#      has_ui_tests: false
-#      has_unit_tests: ${{ parameters.has_unit_tests }}
+  # macOS Python 3.9 build
+  - template: run-tests-with.yml
+    parameters:
+      image_name: 'macOS-11'
+      qt_wrapper: PySide2==5.15.2
+      python_version: 3.9
+      job_name: "macOS Python 3.9"
+      # pass through all parameters.
+      extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+      tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+      additional_repositories: ${{ parameters.additional_repositories }}
+      tk_core_ref: ${{ parameters.tk_core_ref }}
+      post_tests_steps: ${{ parameters.post_tests_steps }}
+      # Force UI tests off for platforms that don't support them yet.
+      has_ui_tests: false
+      has_unit_tests: ${{ parameters.has_unit_tests }}
 #
 #  # Linux Python 3.9 build
 #  - template: run-tests-with.yml

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -10,7 +10,7 @@
 
 parameters:
   # List of Python packages that need to be pip installed for testing.
-  extra_test_dependencies: [ ]
+  extra_test_dependencies: []
   # Git ref of tk-toolchain to use.
   tk_toolchain_ref: master
   # List of repositories to clone alongside this repository.
@@ -20,7 +20,7 @@ parameters:
   # - name: tk-framework-shotgunutils
   # - name: tk-framework-qtwidgets
   #   ref: <branch-or-tag>
-  additional_repositories: [ ]
+  additional_repositories: []
   # Git ref of tk-core to use.
   tk_core_ref: master
   # Post test steps
@@ -31,7 +31,7 @@ parameters:
   # post_tests_steps:
   # - bash: do_something
   # - bash: do_something_else
-  post_tests_steps: [ ]
+  post_tests_steps: []
   # If set to true, the build agent will install the necessary libraries to run ui tests.
   has_ui_tests: false
   # If set to true, the build agent will run unit tests.

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -157,7 +157,6 @@ jobs:
           has_ui_tests: false
           has_unit_tests: ${{ parameters.has_unit_tests }}
 
-      # PYTHON 3.9
       # Windows python 3.9 build
       - template: run-tests-with.yml
         parameters:
@@ -191,7 +190,7 @@ jobs:
           # Force UI tests off for platforms that don't support them yet.
           has_ui_tests: false
           has_unit_tests: ${{ parameters.has_unit_tests }}
-      #
+
       # Linux Python 3.9 build
       - template: run-tests-with.yml
         parameters:

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -156,3 +156,55 @@ jobs:
       # Force UI tests off for platforms that don't support them yet.
       has_ui_tests: false
       has_unit_tests: ${{ parameters.has_unit_tests }}
+
+  # PYTHON 3.9
+  # Windows python 3.9 build
+  - template: run-tests-with.yml
+    parameters:
+      image_name: 'windows-2022'
+      qt_wrapper: PySide2==5.14.1
+      python_version: 3.9
+      job_name: "Windows Python 3.9"
+      # pass through all parameters
+      extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+      tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+      additional_repositories: ${{ parameters.additional_repositories }}
+      tk_core_ref: ${{ parameters.tk_core_ref }}
+      post_tests_steps: ${{ parameters.post_tests_steps }}
+      # Force UI tests off for platforms that don't support them yet.
+      has_ui_tests: false
+      has_unit_tests: ${{ parameters.has_unit_tests }}
+
+#  # macOS Python 3.9 build
+#  - template: run-tests-with.yml
+#    parameters:
+#      image_name: 'macos-10.15'
+#      qt_wrapper: PySide2==5.14.1
+#      python_version: 3.9
+#      job_name: "macOS Python 3.9"
+#      # pass through all parameters.
+#      extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+#      tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+#      additional_repositories: ${{ parameters.additional_repositories }}
+#      tk_core_ref: ${{ parameters.tk_core_ref }}
+#      post_tests_steps: ${{ parameters.post_tests_steps }}
+#      # Force UI tests off for platforms that don't support them yet.
+#      has_ui_tests: false
+#      has_unit_tests: ${{ parameters.has_unit_tests }}
+#
+#  # Linux Python 3.9 build
+#  - template: run-tests-with.yml
+#      parameters:
+#        image_name: 'ubuntu-18.04'
+#        qt_wrapper: PySide2==5.14.1
+#        python_version: 3.9
+#        job_name: "Linux Python 3.9"
+#        # pass through all parameters
+#        extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+#        tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+#        additional_repositories: ${{ parameters.additional_repositories }}
+#        tk_core_ref: ${{ parameters.tk_core_ref }}
+#        post_tests_steps: ${{ parameters.post_tests_steps }}
+#        # Force UI tests off for platforms that don't support them yet.
+#        has_ui_tests: false
+#        has_unit_tests: ${{ parameters.has_unit_tests }}

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -192,19 +192,19 @@ jobs:
       has_ui_tests: false
       has_unit_tests: ${{ parameters.has_unit_tests }}
 #
-#  # Linux Python 3.9 build
-#  - template: run-tests-with.yml
-#      parameters:
-#        image_name: 'ubuntu-18.04'
-#        qt_wrapper: PySide2==5.14.1
-#        python_version: 3.9
-#        job_name: "Linux Python 3.9"
-#        # pass through all parameters
-#        extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-#        tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-#        additional_repositories: ${{ parameters.additional_repositories }}
-#        tk_core_ref: ${{ parameters.tk_core_ref }}
-#        post_tests_steps: ${{ parameters.post_tests_steps }}
-#        # Force UI tests off for platforms that don't support them yet.
-#        has_ui_tests: false
-#        has_unit_tests: ${{ parameters.has_unit_tests }}
+  # Linux Python 3.9 build
+  - template: run-tests-with.yml
+      parameters:
+        image_name: 'ubuntu-20.04'
+        qt_wrapper: PySide2==5.15.2
+        python_version: 3.9
+        job_name: "Linux Python 3.9"
+        # pass through all parameters
+        extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+        tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+        additional_repositories: ${{ parameters.additional_repositories }}
+        tk_core_ref: ${{ parameters.tk_core_ref }}
+        post_tests_steps: ${{ parameters.post_tests_steps }}
+        # Force UI tests off for platforms that don't support them yet.
+        has_ui_tests: false
+        has_unit_tests: ${{ parameters.has_unit_tests }}

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -199,7 +199,7 @@ jobs:
         qt_wrapper: PySide2==5.15.2
         python_version: 3.9
         job_name: "Linux Python 3.9"
-        # pass through all parameters
+        # pass through all parameters.
         extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
         tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
         additional_repositories: ${{ parameters.additional_repositories }}

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -10,7 +10,7 @@
 
 parameters:
   # List of Python packages that need to be pip installed for testing.
-  extra_test_dependencies: []
+  extra_test_dependencies: [ ]
   # Git ref of tk-toolchain to use.
   tk_toolchain_ref: master
   # List of repositories to clone alongside this repository.
@@ -20,7 +20,7 @@ parameters:
   # - name: tk-framework-shotgunutils
   # - name: tk-framework-qtwidgets
   #   ref: <branch-or-tag>
-  additional_repositories: []
+  additional_repositories: [ ]
   # Git ref of tk-core to use.
   tk_core_ref: master
   # Post test steps
@@ -31,7 +31,7 @@ parameters:
   # post_tests_steps:
   # - bash: do_something
   # - bash: do_something_else
-  post_tests_steps: []
+  post_tests_steps: [ ]
   # If set to true, the build agent will install the necessary libraries to run ui tests.
   has_ui_tests: false
   # If set to true, the build agent will run unit tests.
@@ -70,141 +70,141 @@ parameters:
 
 jobs:
 
-# TODO: We're missing the Linux  Python 2.7 build here. This is because the Python 2.7
-# That Azure Pipelines ships with uses USC4 encoding for strings but PySide1
-# and PySide2 on pip using USC2, which breaks. We should look into building
-# our own copy or creating our own docker container that has Python compiled
-# the right way.
+  # TODO: We're missing the Linux  Python 2.7 build here. This is because the Python 2.7
+  # That Azure Pipelines ships with uses USC4 encoding for strings but PySide1
+  # and PySide2 on pip using USC2, which breaks. We should look into building
+  # our own copy or creating our own docker container that has Python compiled
+  # the right way.
 
-# Windows Python 2.7 build
-- template: run-tests-with.yml
-  parameters:
-    image_name: 'windows-2019'
-    qt_wrapper: PySide
-    python_version: 2.7
-    job_name: "Windows Python 2.7"
-    # pass through all parameters
-    ${{ insert }}: ${{ parameters }}
-
-# Note: The automation library we use is not Python 3 compliant, and our ui tests currently only
-# target Windows which means we run our automation only on Windows and Python 2 for now.
-- ${{ if eq( parameters.has_unit_tests, true ) }}:
-  # Linux Python 3.7 build
-  - template: run-tests-with.yml
-    parameters:
-      image_name: 'ubuntu-18.04'
-      qt_wrapper: PySide2==5.14.1
-      python_version: 3.7
-      job_name: "Linux Python 3.7"
-      # pass through all parameters
-      extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-      tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-      additional_repositories: ${{ parameters.additional_repositories }}
-      tk_core_ref: ${{ parameters.tk_core_ref }}
-      post_tests_steps: ${{ parameters.post_tests_steps }}
-      # Force UI tests off for platforms that don't support them yet.
-      has_ui_tests: false
-      has_unit_tests: ${{ parameters.has_unit_tests }}
-
-  # macOS Python 2.7 build
-  - template: run-tests-with.yml
-    parameters:
-      image_name: 'macos-10.15'
-      qt_wrapper: PySide2==5.14.1
-      python_version: 2.7
-      job_name: "macOS Python 2.7"
-      # pass through all parameters
-      extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-      tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-      additional_repositories: ${{ parameters.additional_repositories }}
-      tk_core_ref: ${{ parameters.tk_core_ref }}
-      post_tests_steps: ${{ parameters.post_tests_steps }}
-      # Force UI tests off for platforms that don't support them yet.
-      has_ui_tests: false
-      has_unit_tests: ${{ parameters.has_unit_tests }}
-
-  # macOS Python 3.7 build
-  - template: run-tests-with.yml
-    parameters:
-      image_name: 'macos-10.15'
-      qt_wrapper: PySide2==5.14.1
-      python_version: 3.7
-      job_name: "macOS Python 3.7"
-      # pass through all parameters.
-      extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-      tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-      additional_repositories: ${{ parameters.additional_repositories }}
-      tk_core_ref: ${{ parameters.tk_core_ref }}
-      post_tests_steps: ${{ parameters.post_tests_steps }}
-      # Force UI tests off for platforms that don't support them yet.
-      has_ui_tests: false
-      has_unit_tests: ${{ parameters.has_unit_tests }}
-
-  # Windows Python 3.7 build
+  # Windows Python 2.7 build
   - template: run-tests-with.yml
     parameters:
       image_name: 'windows-2019'
-      qt_wrapper: PySide2==5.14.1
-      python_version: 3.7
-      job_name: "Windows Python 3.7"
+      qt_wrapper: PySide
+      python_version: 2.7
+      job_name: "Windows Python 2.7"
       # pass through all parameters
-      extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-      tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-      additional_repositories: ${{ parameters.additional_repositories }}
-      tk_core_ref: ${{ parameters.tk_core_ref }}
-      post_tests_steps: ${{ parameters.post_tests_steps }}
-      # Force UI tests off for platforms that don't support them yet.
-      has_ui_tests: false
-      has_unit_tests: ${{ parameters.has_unit_tests }}
+      ${{ insert }}: ${{ parameters }}
 
-  # PYTHON 3.9
-  # Windows python 3.9 build
-  - template: run-tests-with.yml
-    parameters:
-      image_name: 'windows-2022'
-      qt_wrapper: PySide2==5.15.2
-      python_version: 3.9
-      job_name: "Windows Python 3.9"
-      # pass through all parameters
-      extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-      tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-      additional_repositories: ${{ parameters.additional_repositories }}
-      tk_core_ref: ${{ parameters.tk_core_ref }}
-      post_tests_steps: ${{ parameters.post_tests_steps }}
-      # Force UI tests off for platforms that don't support them yet.
-      has_ui_tests: false
-      has_unit_tests: ${{ parameters.has_unit_tests }}
+  # Note: The automation library we use is not Python 3 compliant, and our ui tests currently only
+  # target Windows which means we run our automation only on Windows and Python 2 for now.
+  - ${{ if eq( parameters.has_unit_tests, true ) }}:
+      # Linux Python 3.7 build
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'ubuntu-18.04'
+          qt_wrapper: PySide2==5.14.1
+          python_version: 3.7
+          job_name: "Linux Python 3.7"
+          # pass through all parameters
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          # Force UI tests off for platforms that don't support them yet.
+          has_ui_tests: false
+          has_unit_tests: ${{ parameters.has_unit_tests }}
 
-  # macOS Python 3.9 build
-  - template: run-tests-with.yml
-    parameters:
-      image_name: 'macOS-11'
-      qt_wrapper: PySide2==5.15.2
-      python_version: 3.9
-      job_name: "macOS Python 3.9"
-      # pass through all parameters.
-      extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-      tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-      additional_repositories: ${{ parameters.additional_repositories }}
-      tk_core_ref: ${{ parameters.tk_core_ref }}
-      post_tests_steps: ${{ parameters.post_tests_steps }}
-      # Force UI tests off for platforms that don't support them yet.
-      has_ui_tests: false
-      has_unit_tests: ${{ parameters.has_unit_tests }}
-#
-  # Linux Python 3.9 build
-  - template: run-tests-with.yml
-      parameters:
-        image_name: 'ubuntu-20.04'
-        qt_wrapper: PySide2==5.15.2
-        python_version: 3.9
-        job_name: "Linux Python 3.9"
-        # pass through all parameters.
-        extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-        tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-        additional_repositories: ${{ parameters.additional_repositories }}
-        tk_core_ref: ${{ parameters.tk_core_ref }}
-        post_tests_steps: ${{ parameters.post_tests_steps }}
-        # Force UI tests off for platforms that don't support them yet.
-        has_ui_tests: false
-        has_unit_tests: ${{ parameters.has_unit_tests }}
+      # macOS Python 2.7 build
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'macos-10.15'
+          qt_wrapper: PySide2==5.14.1
+          python_version: 2.7
+          job_name: "macOS Python 2.7"
+          # pass through all parameters
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          # Force UI tests off for platforms that don't support them yet.
+          has_ui_tests: false
+          has_unit_tests: ${{ parameters.has_unit_tests }}
+
+      # macOS Python 3.7 build
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'macos-10.15'
+          qt_wrapper: PySide2==5.14.1
+          python_version: 3.7
+          job_name: "macOS Python 3.7"
+          # pass through all parameters.
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          # Force UI tests off for platforms that don't support them yet.
+          has_ui_tests: false
+          has_unit_tests: ${{ parameters.has_unit_tests }}
+
+      # Windows Python 3.7 build
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'windows-2019'
+          qt_wrapper: PySide2==5.14.1
+          python_version: 3.7
+          job_name: "Windows Python 3.7"
+          # pass through all parameters
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          # Force UI tests off for platforms that don't support them yet.
+          has_ui_tests: false
+          has_unit_tests: ${{ parameters.has_unit_tests }}
+
+      # PYTHON 3.9
+      # Windows python 3.9 build
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'windows-2022'
+          qt_wrapper: PySide2==5.15.2
+          python_version: 3.9
+          job_name: "Windows Python 3.9"
+          # pass through all parameters
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          # Force UI tests off for platforms that don't support them yet.
+          has_ui_tests: false
+          has_unit_tests: ${{ parameters.has_unit_tests }}
+
+      # macOS Python 3.9 build
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'macOS-11'
+          qt_wrapper: PySide2==5.15.2
+          python_version: 3.9
+          job_name: "macOS Python 3.9"
+          # pass through all parameters.
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          # Force UI tests off for platforms that don't support them yet.
+          has_ui_tests: false
+          has_unit_tests: ${{ parameters.has_unit_tests }}
+      #
+      # Linux Python 3.9 build
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'ubuntu-20.04'
+          qt_wrapper: PySide2==5.15.2
+          python_version: 3.9
+          job_name: "Linux Python 3.9"
+          # pass through all parameters.
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          # Force UI tests off for platforms that don't support them yet.
+          has_ui_tests: false
+          has_unit_tests: ${{ parameters.has_unit_tests }}

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -162,7 +162,7 @@ jobs:
   - template: run-tests-with.yml
     parameters:
       image_name: 'windows-2022'
-      qt_wrapper: PySide2==5.14.1
+      qt_wrapper: PySide2==5.15.2
       python_version: 3.9
       job_name: "Windows Python 3.9"
       # pass through all parameters


### PR DESCRIPTION
Modifying tk-ci-tools to run tests under Python 3.9 on all platforms.