### PR TITLE
Fix issue about deprecated flag when doing pip install

### DIFF
--- a/internal/pip-install-packages.yml
+++ b/internal/pip-install-packages.yml
@@ -14,5 +14,5 @@ parameters:
 
 steps:
 - ${{ each package in parameters.packages }}:
-   - bash: pip install ${{ package }} --use-feature=2020-resolver
+   - bash: pip install ${{ package }}
      displayName: Install Python package ${{ package }}


### PR DESCRIPTION
Remove flag --use-feature=2020-resolver when installing a package