### PR TITLE
SG-29495 Remove python 2 from tk-framework-desktopserver

### DIFF
--- a/build-pipeline.yml
+++ b/build-pipeline.yml
@@ -44,6 +44,10 @@ parameters:
   - name: has_ui_tests
     type: boolean
     default: false
+  # Tells the build pipeline that there are python 2.7 tests to execute
+  - name: has_python_27_tests
+    type: boolean
+    default: true
   # Post test steps
   # This is a list of Azure Pipeline steps that will be inserted
   # right after the tests were run.

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -77,14 +77,15 @@ jobs:
   # the right way.
 
   # Windows Python 2.7 build
-  - template: run-tests-with.yml
-    parameters:
-      image_name: 'windows-2022'
-      qt_wrapper: PySide
-      python_version: 2.7
-      job_name: "Windows Python 2.7"
-      # pass through all parameters
-      ${{ insert }}: ${{ parameters }}
+  - ${{ if eq( parameters.has_python_27_tests, true ) }}:
+    - template: run-tests-with.yml
+      parameters:
+        image_name: 'windows-2022'
+        qt_wrapper: PySide
+        python_version: 2.7
+        job_name: "Windows Python 2.7"
+        # pass through all parameters
+        ${{ insert }}: ${{ parameters }}
 
   # Note: The automation library we use is not Python 3 compliant, and our ui tests currently only
   # target Windows which means we run our automation only on Windows and Python 2 for now.
@@ -107,21 +108,22 @@ jobs:
           has_unit_tests: ${{ parameters.has_unit_tests }}
 
       # macOS Python 2.7 build
-      - template: run-tests-with.yml
-        parameters:
-          image_name: 'macos-12'
-          qt_wrapper: PySide2==5.14.1
-          python_version: 2.7
-          job_name: "macOS Python 2.7"
-          # pass through all parameters
-          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-          additional_repositories: ${{ parameters.additional_repositories }}
-          tk_core_ref: ${{ parameters.tk_core_ref }}
-          post_tests_steps: ${{ parameters.post_tests_steps }}
-          # Force UI tests off for platforms that don't support them yet.
-          has_ui_tests: false
-          has_unit_tests: ${{ parameters.has_unit_tests }}
+      - ${{ if eq( parameters.has_python_27_tests, true ) }}:
+        - template: run-tests-with.yml
+          parameters:
+            image_name: 'macos-12'
+            qt_wrapper: PySide2==5.14.1
+            python_version: 2.7
+            job_name: "macOS Python 2.7"
+            # pass through all parameters
+            extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+            tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+            additional_repositories: ${{ parameters.additional_repositories }}
+            tk_core_ref: ${{ parameters.tk_core_ref }}
+            post_tests_steps: ${{ parameters.post_tests_steps }}
+            # Force UI tests off for platforms that don't support them yet.
+            has_ui_tests: false
+            has_unit_tests: ${{ parameters.has_unit_tests }}
 
       # macOS Python 3.7 build
       - template: run-tests-with.yml


### PR DESCRIPTION
This PR include a flag to disable python 2.7 pass if needed