### PR TITLE
Temporarly update known_hosts on github agents

### DIFF
--- a/internal/release-to-appstore.yml
+++ b/internal/release-to-appstore.yml
@@ -16,6 +16,7 @@ steps:
 # We don't need to call the internal script's prepare_repo.sh since we will be stating with a fresh environment each time
 # which is setup by Azure. So just clone the repo and install the requirements.
 - bash: |
+    ssh-keyscan github.com > ~/.ssh/known_hosts
     git clone --depth 1 git@github.com:$RELEASE_REPO --branch ${{ parameters.release_repo_ref }}  ../release_scripts
     pip install -r ../release_scripts/app_store/requirements.txt
   env:


### PR DESCRIPTION
Adds a command to push the new GitHub fingerprint to the Azure Pipeline's agents. Ideally, we will revert to this next week.

Without this: https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/results?buildId=8908&view=logs&j=38f35a1f-12cb-5c95-5523-bec68b254af6&t=8139b6ad-dca4-589a-73bc-a19fced413d9

Reason: https://github.blog/2023-03-23-we-updated-our-rsa-ssh-host-key/