### PR TITLE
Revert "Temporarly update known_hosts on github agents"

### DIFF
--- a/internal/release-to-appstore.yml
+++ b/internal/release-to-appstore.yml
@@ -16,7 +16,6 @@ steps:
 # We don't need to call the internal script's prepare_repo.sh since we will be stating with a fresh environment each time
 # which is setup by Azure. So just clone the repo and install the requirements.
 - bash: |
-    ssh-keyscan github.com > ~/.ssh/known_hosts
     git clone --depth 1 git@github.com:$RELEASE_REPO --branch ${{ parameters.release_repo_ref }}  ../release_scripts
     pip install -r ../release_scripts/app_store/requirements.txt
   env:


### PR DESCRIPTION
The github.com known_hosts should have been updated on our build agents now. I am reverting the change to slightly improve our security posture.

Reverts shotgunsoftware/tk-ci-tools#34

