### PR TITLE
SG-24427 Update GitHub.com copy of mpas ma to the python3 version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+.idea/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,9 +82,9 @@ jobs:
         TK_TOOLCHAIN_USER_PASSWORD: $(sg.ci.human.password)
       displayName: Testing CI human user credentials
     # Ensures the Shotgun user credentials can connect to the UI Automation site.
-    - bash: PYTHONPATH=../tk-core/python python tests/test_credentials.py
-      env:
-        TK_TOOLCHAIN_HOST: $(sg.ui.host)
-        TK_TOOLCHAIN_USER_LOGIN: $(sg.ui.human.login)
-        TK_TOOLCHAIN_USER_PASSWORD: $(sg.ui.human.password)
-      displayName: Testing UI Automation human user credentials
+    # - bash: PYTHONPATH=../tk-core/python python tests/test_credentials.py
+    #   env:
+    #     TK_TOOLCHAIN_HOST: $(sg.ui.host)
+    #     TK_TOOLCHAIN_USER_LOGIN: $(sg.ui.human.login)
+    #     TK_TOOLCHAIN_USER_PASSWORD: $(sg.ui.human.password)
+    #   displayName: Testing UI Automation human user credentials

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,10 +81,3 @@ jobs:
         TK_TOOLCHAIN_USER_LOGIN: $(sg.ci.human.login)
         TK_TOOLCHAIN_USER_PASSWORD: $(sg.ci.human.password)
       displayName: Testing CI human user credentials
-    # Ensures the Shotgun user credentials can connect to the UI Automation site.
-    # - bash: PYTHONPATH=../tk-core/python python tests/test_credentials.py
-    #   env:
-    #     TK_TOOLCHAIN_HOST: $(sg.ui.host)
-    #     TK_TOOLCHAIN_USER_LOGIN: $(sg.ui.human.login)
-    #     TK_TOOLCHAIN_USER_PASSWORD: $(sg.ui.human.password)
-    #   displayName: Testing UI Automation human user credentials

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,3 +81,10 @@ jobs:
         TK_TOOLCHAIN_USER_LOGIN: $(sg.ci.human.login)
         TK_TOOLCHAIN_USER_PASSWORD: $(sg.ci.human.password)
       displayName: Testing CI human user credentials
+    # Ensures the Shotgun user credentials can connect to the UI Automation site.
+    - bash: PYTHONPATH=../tk-core/python python tests/test_credentials.py
+      env:
+        TK_TOOLCHAIN_HOST: $(sg.ui.host)
+        TK_TOOLCHAIN_USER_LOGIN: $(sg.ui.human.login)
+        TK_TOOLCHAIN_USER_PASSWORD: $(sg.ui.human.password)
+      displayName: Testing UI Automation human user credentials

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ jobs:
     # framework is missing, so it's important that has_ui_tests triggers a clone
     # only for builds we can run automation for.
     - bash: |
-        PYTHONPATH=../ui_automation python tests/test_ui_automation.py
+        python tests/test_ui_automation.py
       displayName: Testing import of UI automation framework.
     - bash: |
         python tests/test_repo_release_cloning.py

--- a/build-pipeline.yml
+++ b/build-pipeline.yml
@@ -66,6 +66,12 @@ parameters:
   - name: release_repo_ref
     type: string
     default: master
+  # MPAS-MA repo ref value to be installed.
+  # We're using a github.com private sync with the latest working value in order to
+  # install that MA module version.
+  - name: ui_automation_ref
+    type: string
+    default: d621a86d52eb9d45704393a9d5cc02b30e836a8e
 
 # This build pipeline will validate the code style and our test suite on
 # multiple platforms.
@@ -91,6 +97,7 @@ jobs:
         post_tests_steps: ${{ parameters.post_tests_steps }}
         has_unit_tests: ${{ parameters.has_unit_tests }}
         has_ui_tests: ${{ parameters.has_ui_tests }}
+        ui_automation_ref: ${{ parameters.ui_automation_ref }}
 
 # If the build was launched because a tag was created, we'll want to deploy
 # this to the AppStore.

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -113,6 +113,7 @@ jobs:
     - template: install-ssh-key.yml
     - bash: |
         ssh-keyscan github.com > ~/.ssh/known_hosts
+        echo Cloning git@github.com:$UI_AUTOMATION_REPO 
         git clone --depth 1 git@github.com:$UI_AUTOMATION_REPO ../ui_automation
       displayName: Cloning UI automation tools
       env:

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -134,7 +134,7 @@ jobs:
   # as "coverage combine" will combine all coverage files that match .coverage.*.
   - bash: |
       (test -e .coveragerc && echo ".coveragerc was found." ) || ((python -c "print('[run]\nsource=.\nomit=\n    tests/*\n[report]\n\nexclude_lines =\n    raise NotImplementedError')" > .coveragerc) && echo "Generated .coveragerc")
-      COVERAGE_FILE=.coverage.tests python -m pytest tests --cov --cov-report xml -vv -s
+      COVERAGE_FILE=.coverage.tests python -m pytest tests --cov --cov-report xml -vv -s -tb=long
     # These environment variables need to be set so Linux runs can connect
     # to xvfb and to have complete logging. Each test logging output will
     # be captured by pytest and displayed on failure.

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -113,9 +113,7 @@ jobs:
     - template: install-ssh-key.yml
     - bash: |
         ssh-keyscan github.com > ~/.ssh/known_hosts
-        pwd
         git clone --depth 1 -b ${{ parameters.ui_automation_ref }} --single-branch git@github.com:$UI_AUTOMATION_REPO ../ui_automation
-        ls -al ../ui_automation
         pip install /d/a/1/ui_automation
       displayName: Cloning and pip install UI automation tools
       env:

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -134,7 +134,7 @@ jobs:
   # as "coverage combine" will combine all coverage files that match .coverage.*.
   - bash: |
       (test -e .coveragerc && echo ".coveragerc was found." ) || ((python -c "print('[run]\nsource=.\nomit=\n    tests/*\n[report]\n\nexclude_lines =\n    raise NotImplementedError')" > .coveragerc) && echo "Generated .coveragerc")
-      COVERAGE_FILE=.coverage.tests python -m pytest tests --cov --cov-report xml -vv -s -tb=long
+      COVERAGE_FILE=.coverage.tests python -m pytest tests --cov --cov-report xml -vv -s -tb=line
     # These environment variables need to be set so Linux runs can connect
     # to xvfb and to have complete logging. Each test logging output will
     # be captured by pytest and displayed on failure.

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -134,7 +134,7 @@ jobs:
   # as "coverage combine" will combine all coverage files that match .coverage.*.
   - bash: |
       (test -e .coveragerc && echo ".coveragerc was found." ) || ((python -c "print('[run]\nsource=.\nomit=\n    tests/*\n[report]\n\nexclude_lines =\n    raise NotImplementedError')" > .coveragerc) && echo "Generated .coveragerc")
-      COVERAGE_FILE=.coverage.tests python -m pytest tests --cov --cov-report xml -vv -s --tb=long
+      COVERAGE_FILE=.coverage.tests python -m pytest tests --cov --cov-report xml -vv -s
     # These environment variables need to be set so Linux runs can connect
     # to xvfb and to have complete logging. Each test logging output will
     # be captured by pytest and displayed on failure.

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -145,9 +145,9 @@ jobs:
       CI: 1
       # Allows to connect to a real Shotgun site during a test. Use sparingly to avoid
       # slowing down automation. Using Mockgun is still the best way to have speedy tests.
-      TK_TOOLCHAIN_HOST: $(sg.ci.host)
-      TK_TOOLCHAIN_USER_LOGIN: $(sg.ci.human.login)
-      TK_TOOLCHAIN_USER_PASSWORD: $(sg.ci.human.password)
+      TK_TOOLCHAIN_HOST: $(sg.ui.host)
+      TK_TOOLCHAIN_USER_LOGIN: $(sg.ui.human.login)
+      TK_TOOLCHAIN_USER_PASSWORD: $(sg.ui.human.password)
       SHOTGUN_TEST_ENTITY_SUFFIX: '$(Agent.Name)'
     displayName: Run tests
 

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -113,7 +113,6 @@ jobs:
     - template: install-ssh-key.yml
     - bash: |
         ssh-keyscan github.com > ~/.ssh/known_hosts
-        echo Cloning git@github.com:$UI_AUTOMATION_REPO 
         git clone --depth 1 -b ${{ parameters.ui_automation_ref }} --single-branch git@github.com:$UI_AUTOMATION_REPO ../ui_automation
       displayName: Cloning UI automation tools
       env:

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -124,7 +124,8 @@ jobs:
     - bash: |
         git checkout ${{ parameters.ui_automation_ref }}
         pip install .
-      displayName: PIP install UI automation tools
+        pip install --force-reinstall comtypes==1.1.14
+      displayName: PIP install UI automation tools and comtypes 1.1.14
       workingDirectory: ../ui_automation
 
   # Run the tests. The task will create a simple coverage file if one is missing.

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -112,9 +112,8 @@ jobs:
   - ${{ if and(eq(parameters.has_ui_tests, true), eq( variables['System.TeamProject'], 'Toolkit' )) }}:
     - template: install-ssh-key.yml
     - bash: |
-        ssh-keyscan github.com > ~/.ssh/known_hosts
-        git clone --depth 1 -b ${{ parameters.ui_automation_ref }} --single-branch git@github.com:$UI_AUTOMATION_REPO ../ui_automation
-      displayName: Cloning UI automation tools
+        pip install -I git+https://github.com/shotgunsoftware/mpas-ma@${{ parameters.ui_automation_ref }}#egg=MA
+      displayName: Pip install UI automation tools
       env:
         UI_AUTOMATION_REPO: $(repo.ui_automation)
 

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -115,7 +115,7 @@ jobs:
         ssh-keyscan github.com > ~/.ssh/known_hosts
         pwd
         git clone --depth 1 -b ${{ parameters.ui_automation_ref }} --single-branch git@github.com:$UI_AUTOMATION_REPO ../ui_automation
-        pip install ../ui_automation/mpas-ma
+        pip install /d/a/1/ui_automation/mpas-ma
       displayName: Cloning and pip install UI automation tools
       env:
         UI_AUTOMATION_REPO: $(repo.ui_automation)

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -114,7 +114,7 @@ jobs:
     - bash: |
         ssh-keyscan github.com > ~/.ssh/known_hosts
         echo Cloning git@github.com:$UI_AUTOMATION_REPO 
-        git clone --depth 1 git@github.com:$UI_AUTOMATION_REPO ../ui_automation
+        git clone --depth 1 -b ${{ parameters.ui_automation_ref }} --single-branch git@github.com:$UI_AUTOMATION_REPO ../ui_automation
       displayName: Cloning UI automation tools
       env:
         UI_AUTOMATION_REPO: $(repo.ui_automation)

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -48,6 +48,8 @@ parameters:
   # When set to true, the agents for all platforms are set so tests can be executed
   # on all platforms.
   has_unit_tests: true
+  # MPAS-MA repo ref value to be installed.
+  ui_automation_ref: ""
 
 jobs:
 - job:
@@ -114,11 +116,16 @@ jobs:
     - bash: |
         ssh-keyscan github.com > ~/.ssh/known_hosts
         git clone --depth 1 --single-branch git@github.com:$UI_AUTOMATION_REPO ../ui_automation
-        pip install /d/a/1/ui_automation
-      displayName: Cloning and pip install UI automation tools
+      displayName: Cloning UI automation tools
       env:
         # repo.ui_automation can be found on Azure Pipelines Library
         UI_AUTOMATION_REPO: $(repo.ui_automation)
+
+    - bash: |
+        git checkout ${{ parameters.ui_automation_ref }}
+        pip install .
+      displayName: PIP install UI automation tools
+      workingDirectory: ../ui_automation
 
   # Run the tests. The task will create a simple coverage file if one is missing.
   # It will include all code except for the "tests" folder.

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -116,7 +116,7 @@ jobs:
         pwd
         git clone --depth 1 -b ${{ parameters.ui_automation_ref }} --single-branch git@github.com:$UI_AUTOMATION_REPO ../ui_automation
         ls -al ../ui_automation
-        pip install /d/a/1/ui_automation/mpas-ma
+        pip install /d/a/1/ui_automation
       displayName: Cloning and pip install UI automation tools
       env:
         UI_AUTOMATION_REPO: $(repo.ui_automation)

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -112,6 +112,7 @@ jobs:
   - ${{ if and(eq(parameters.has_ui_tests, true), eq( variables['System.TeamProject'], 'Toolkit' )) }}:
     - template: install-ssh-key.yml
     - bash: |
+        ssh-keyscan github.com > ~/.ssh/known_hosts
         git clone --depth 1 git@github.com:$UI_AUTOMATION_REPO ../ui_automation
       displayName: Cloning UI automation tools
       env:

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -109,13 +109,13 @@ jobs:
   # in theory have a project named Toolkit and run these commands. In practice however,
   # all tests tasks require access to our secrets so they can't be used and the build will
   # fail.
-  - ${{ if and(eq(parameters.has_ui_tests, true), eq( variables['System.TeamProject'], 'Toolkit' )) }}:
-    - template: install-ssh-key.yml
-    - bash: |
-        pip install -I git+https://github.com/shotgunsoftware/mpas-ma@${{ parameters.ui_automation_ref }}#egg=MA
-      displayName: Pip install UI automation tools
-      env:
-        UI_AUTOMATION_REPO: $(repo.ui_automation)
+#  - ${{ if and(eq(parameters.has_ui_tests, true), eq( variables['System.TeamProject'], 'Toolkit' )) }}:
+#    - template: install-ssh-key.yml
+#    - bash: |
+#        pip install -I git+https://github.com/shotgunsoftware/mpas-ma@${{ parameters.ui_automation_ref }}#egg=MA
+#      displayName: Pip install UI automation tools
+#      env:
+#        UI_AUTOMATION_REPO: $(repo.ui_automation)
 
   # Run the tests. The task will create a simple coverage file if one is missing.
   # It will include all code except for the "tests" folder.

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -115,6 +115,7 @@ jobs:
         ssh-keyscan github.com > ~/.ssh/known_hosts
         pwd
         git clone --depth 1 -b ${{ parameters.ui_automation_ref }} --single-branch git@github.com:$UI_AUTOMATION_REPO ../ui_automation
+        ls -al ../ui_automation
         pip install /d/a/1/ui_automation/mpas-ma
       displayName: Cloning and pip install UI automation tools
       env:

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -134,7 +134,7 @@ jobs:
   # as "coverage combine" will combine all coverage files that match .coverage.*.
   - bash: |
       (test -e .coveragerc && echo ".coveragerc was found." ) || ((python -c "print('[run]\nsource=.\nomit=\n    tests/*\n[report]\n\nexclude_lines =\n    raise NotImplementedError')" > .coveragerc) && echo "Generated .coveragerc")
-      PYTHONPATH=../ui_automation COVERAGE_FILE=.coverage.tests python -m pytest tests --cov --cov-report xml -vv
+      COVERAGE_FILE=.coverage.tests python -m pytest tests --cov --cov-report xml -vv -s
     # These environment variables need to be set so Linux runs can connect
     # to xvfb and to have complete logging. Each test logging output will
     # be captured by pytest and displayed on failure.

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -113,10 +113,11 @@ jobs:
     - template: install-ssh-key.yml
     - bash: |
         ssh-keyscan github.com > ~/.ssh/known_hosts
-        git clone --depth 1 -b ${{ parameters.ui_automation_ref }} --single-branch git@github.com:$UI_AUTOMATION_REPO ../ui_automation
+        git clone --depth 1 --single-branch git@github.com:$UI_AUTOMATION_REPO ../ui_automation
         pip install /d/a/1/ui_automation
       displayName: Cloning and pip install UI automation tools
       env:
+        # repo.ui_automation can be found on Azure Pipelines Library
         UI_AUTOMATION_REPO: $(repo.ui_automation)
 
   # Run the tests. The task will create a simple coverage file if one is missing.

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -110,10 +110,15 @@ jobs:
   # all tests tasks require access to our secrets so they can't be used and the build will
   # fail.
   - ${{ if and(eq(parameters.has_ui_tests, true), eq( variables['System.TeamProject'], 'Toolkit' )) }}:
-    - template: pip-install-packages.yml
-      parameters:
-        packages:
-          - git+https://github.com/shotgunsoftware/mpas-ma@${{ parameters.ui_automation_ref }}#egg=MA
+    - template: install-ssh-key.yml
+    - bash: |
+        ssh-keyscan github.com > ~/.ssh/known_hosts
+        pwd
+        git clone --depth 1 -b ${{ parameters.ui_automation_ref }} --single-branch git@github.com:$UI_AUTOMATION_REPO ../ui_automation
+        pip install ../ui_automation/mpas-ma
+      displayName: Cloning and pip install UI automation tools
+      env:
+        UI_AUTOMATION_REPO: $(repo.ui_automation)
 
   # Run the tests. The task will create a simple coverage file if one is missing.
   # It will include all code except for the "tests" folder.

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -109,13 +109,11 @@ jobs:
   # in theory have a project named Toolkit and run these commands. In practice however,
   # all tests tasks require access to our secrets so they can't be used and the build will
   # fail.
-#  - ${{ if and(eq(parameters.has_ui_tests, true), eq( variables['System.TeamProject'], 'Toolkit' )) }}:
-#    - template: install-ssh-key.yml
-#    - bash: |
-#        pip install -I git+https://github.com/shotgunsoftware/mpas-ma@${{ parameters.ui_automation_ref }}#egg=MA
-#      displayName: Pip install UI automation tools
-#      env:
-#        UI_AUTOMATION_REPO: $(repo.ui_automation)
+  - ${{ if and(eq(parameters.has_ui_tests, true), eq( variables['System.TeamProject'], 'Toolkit' )) }}:
+    - template: pip-install-packages.yml
+      parameters:
+        packages:
+          - git+https://github.com/shotgunsoftware/mpas-ma@${{ parameters.ui_automation_ref }}#egg=MA
 
   # Run the tests. The task will create a simple coverage file if one is missing.
   # It will include all code except for the "tests" folder.

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -134,7 +134,7 @@ jobs:
   # as "coverage combine" will combine all coverage files that match .coverage.*.
   - bash: |
       (test -e .coveragerc && echo ".coveragerc was found." ) || ((python -c "print('[run]\nsource=.\nomit=\n    tests/*\n[report]\n\nexclude_lines =\n    raise NotImplementedError')" > .coveragerc) && echo "Generated .coveragerc")
-      COVERAGE_FILE=.coverage.tests python -m pytest tests --cov --cov-report xml -vv -s -tb=line
+      COVERAGE_FILE=.coverage.tests python -m pytest tests --cov --cov-report xml -vv -s --tb=long
     # These environment variables need to be set so Linux runs can connect
     # to xvfb and to have complete logging. Each test logging output will
     # be captured by pytest and displayed on failure.

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -145,9 +145,9 @@ jobs:
       CI: 1
       # Allows to connect to a real Shotgun site during a test. Use sparingly to avoid
       # slowing down automation. Using Mockgun is still the best way to have speedy tests.
-      TK_TOOLCHAIN_HOST: $(sg.ui.host)
-      TK_TOOLCHAIN_USER_LOGIN: $(sg.ui.human.login)
-      TK_TOOLCHAIN_USER_PASSWORD: $(sg.ui.human.password)
+      TK_TOOLCHAIN_HOST: $(sg.ci.host)
+      TK_TOOLCHAIN_USER_LOGIN: $(sg.ci.human.login)
+      TK_TOOLCHAIN_USER_PASSWORD: $(sg.ci.human.password)
       SHOTGUN_TEST_ENTITY_SUFFIX: '$(Agent.Name)'
     displayName: Run tests
 

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -150,7 +150,7 @@ jobs:
           python_version: 3.7
           job_name: "Windows Python 3.7"
           # pass through all parameters
-          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          extra_test_dependencies: [Qt.py, comtypes]
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -152,7 +152,7 @@ jobs:
           python_version: 3.7
           job_name: "Windows Python 3.7"
           # pass through all parameters
-          extra_test_dependencies: [Qt.py, comtypes==1.1.14]
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}
@@ -170,7 +170,7 @@ jobs:
           python_version: 3.9
           job_name: "Windows Python 3.9"
           # pass through all parameters
-          extra_test_dependencies: [Qt.py, comtypes==1.1.14]
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -145,7 +145,7 @@ jobs:
       # Windows Python 3.7 build
       - template: run-tests-with.yml
         parameters:
-          image_name: 'windows-2022'
+          image_name: 'windows-2019'
           qt_wrapper: PySide2==5.14.1
           python_version: 3.7
           job_name: "Windows Python 3.7"
@@ -163,7 +163,7 @@ jobs:
       # Windows python 3.9 build
       - template: run-tests-with.yml
         parameters:
-          image_name: 'windows-2022'
+          image_name: 'windows-2019'
           qt_wrapper: PySide2==5.15.2
           python_version: 3.9
           job_name: "Windows Python 3.9"

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -106,7 +106,7 @@ jobs:
           # Force UI tests off for platforms that don't support them yet.
           has_ui_tests: false
           has_unit_tests: ${{ parameters.has_unit_tests }}
-          ui_automation_ref: merging-from-git-autodesk
+          ui_automation_ref: master
 
       # macOS Python 2.7 build
       - ${{ if eq( parameters.has_python_27_tests, true ) }}:

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -36,6 +36,8 @@ parameters:
   has_ui_tests: false
   # If set to true, the build agent will run unit tests.
   has_unit_tests: true
+  # MPAS-MA repo ref value to be installed.
+  ui_automation_ref: ""
 
 # TODO: At some point, we should review how these environments are enumerated.
 # Something like:
@@ -158,6 +160,7 @@ jobs:
           # Force UI tests off for platforms that don't support them yet.
           has_ui_tests: ${{ parameters.has_ui_tests }}
           has_unit_tests: ${{ parameters.has_unit_tests }}
+          ui_automation_ref: ${{ parameters.ui_automation_ref }}
 
       # Windows python 3.9 build
       - template: run-tests-with.yml
@@ -175,6 +178,7 @@ jobs:
           # Force UI tests off for platforms that don't support them yet.
           has_ui_tests: ${{ parameters.has_ui_tests }}
           has_unit_tests: ${{ parameters.has_unit_tests }}
+          ui_automation_ref: ${{ parameters.ui_automation_ref }}
 
       # macOS Python 3.9 build
       - template: run-tests-with.yml

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -156,7 +156,7 @@ jobs:
           tk_core_ref: ${{ parameters.tk_core_ref }}
           post_tests_steps: ${{ parameters.post_tests_steps }}
           # Force UI tests off for platforms that don't support them yet.
-          has_ui_tests: false
+          has_ui_tests: true
           has_unit_tests: ${{ parameters.has_unit_tests }}
 
       # Windows python 3.9 build
@@ -173,7 +173,7 @@ jobs:
           tk_core_ref: ${{ parameters.tk_core_ref }}
           post_tests_steps: ${{ parameters.post_tests_steps }}
           # Force UI tests off for platforms that don't support them yet.
-          has_ui_tests: false
+          has_ui_tests: true
           has_unit_tests: ${{ parameters.has_unit_tests }}
 
       # macOS Python 3.9 build

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -10,7 +10,7 @@
 
 parameters:
   # List of Python packages that need to be pip installed for testing.
-  extra_test_dependencies: [Qt.py, comtypes]
+  extra_test_dependencies: []
   # Git ref of tk-toolchain to use.
   tk_toolchain_ref: master
   # List of repositories to clone alongside this repository.
@@ -150,15 +150,14 @@ jobs:
           python_version: 3.7
           job_name: "Windows Python 3.7"
           # pass through all parameters
-          extra_test_dependencies: [Qt.py, comtypes]
+          extra_test_dependencies: [Qt.py, comtypes==1.1.14]
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}
           post_tests_steps: ${{ parameters.post_tests_steps }}
           # Force UI tests off for platforms that don't support them yet.
-          has_ui_tests: true
+          has_ui_tests: ${{ parameters.has_ui_tests }}
           has_unit_tests: ${{ parameters.has_unit_tests }}
-          ui_automation_ref: merging-from-git-autodesk
 
       # Windows python 3.9 build
       - template: run-tests-with.yml
@@ -168,15 +167,14 @@ jobs:
           python_version: 3.9
           job_name: "Windows Python 3.9"
           # pass through all parameters
-          extra_test_dependencies: [Qt.py, comtypes]
+          extra_test_dependencies: [Qt.py, comtypes==1.1.14]
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}
           post_tests_steps: ${{ parameters.post_tests_steps }}
           # Force UI tests off for platforms that don't support them yet.
-          has_ui_tests: true
+          has_ui_tests: ${{ parameters.has_ui_tests }}
           has_unit_tests: ${{ parameters.has_unit_tests }}
-          ui_automation_ref: merging-from-git-autodesk
 
       # macOS Python 3.9 build
       - template: run-tests-with.yml

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -147,7 +147,7 @@ jobs:
       # Windows Python 3.7 build
       - template: run-tests-with.yml
         parameters:
-          image_name: 'windows-2022 '
+          image_name: 'windows-2019'
           qt_wrapper: PySide2==5.14.1
           python_version: 3.7
           job_name: "Windows Python 3.7"
@@ -165,7 +165,7 @@ jobs:
       # Windows python 3.9 build
       - template: run-tests-with.yml
         parameters:
-          image_name: 'windows-2022 '
+          image_name: 'windows-2019'
           qt_wrapper: PySide2==5.15.2
           python_version: 3.9
           job_name: "Windows Python 3.9"

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -147,7 +147,7 @@ jobs:
       # Windows Python 3.7 build
       - template: run-tests-with.yml
         parameters:
-          image_name: 'windows-2019'
+          image_name: 'windows-2022'
           qt_wrapper: PySide2==5.14.1
           python_version: 3.7
           job_name: "Windows Python 3.7"
@@ -158,14 +158,14 @@ jobs:
           tk_core_ref: ${{ parameters.tk_core_ref }}
           post_tests_steps: ${{ parameters.post_tests_steps }}
           # Force UI tests off for platforms that don't support them yet.
-          has_ui_tests: ${{ parameters.has_ui_tests }}
+          has_ui_tests: false
           has_unit_tests: ${{ parameters.has_unit_tests }}
           ui_automation_ref: ${{ parameters.ui_automation_ref }}
 
       # Windows python 3.9 build
       - template: run-tests-with.yml
         parameters:
-          image_name: 'windows-2019'
+          image_name: 'windows-2022'
           qt_wrapper: PySide2==5.15.2
           python_version: 3.9
           job_name: "Windows Python 3.9"
@@ -176,7 +176,7 @@ jobs:
           tk_core_ref: ${{ parameters.tk_core_ref }}
           post_tests_steps: ${{ parameters.post_tests_steps }}
           # Force UI tests off for platforms that don't support them yet.
-          has_ui_tests: ${{ parameters.has_ui_tests }}
+          has_ui_tests: false
           has_unit_tests: ${{ parameters.has_unit_tests }}
           ui_automation_ref: ${{ parameters.ui_automation_ref }}
 

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -10,7 +10,7 @@
 
 parameters:
   # List of Python packages that need to be pip installed for testing.
-  extra_test_dependencies: []
+  extra_test_dependencies: [Qt.py, comtypes]
   # Git ref of tk-toolchain to use.
   tk_toolchain_ref: master
   # List of repositories to clone alongside this repository.
@@ -87,8 +87,8 @@ jobs:
         # pass through all parameters
         ${{ insert }}: ${{ parameters }}
 
-  # Note: The automation library we use is not Python 3 compliant, and our ui tests currently only
-  # target Windows which means we run our automation only on Windows and Python 2 for now.
+  # Note: Our ui tests currently only target Windows which means we run our automation only
+  # on Windows for now
   - ${{ if eq( parameters.has_unit_tests, true ) }}:
       # Linux Python 3.7 build
       - template: run-tests-with.yml
@@ -106,6 +106,7 @@ jobs:
           # Force UI tests off for platforms that don't support them yet.
           has_ui_tests: false
           has_unit_tests: ${{ parameters.has_unit_tests }}
+          ui_automation_ref: merging-from-git-autodesk
 
       # macOS Python 2.7 build
       - ${{ if eq( parameters.has_python_27_tests, true ) }}:

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -150,7 +150,7 @@ jobs:
           python_version: 3.7
           job_name: "Windows Python 3.7"
           # pass through all parameters
-          extra_test_dependencies: [Qt.py, comtypes, git+https://github.com/shotgunsoftware/mpas-ma@merging-from-git-autodesk#egg=MA]
+          extra_test_dependencies: [Qt.py, comtypes]
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -106,7 +106,6 @@ jobs:
           # Force UI tests off for platforms that don't support them yet.
           has_ui_tests: false
           has_unit_tests: ${{ parameters.has_unit_tests }}
-          ui_automation_ref: master
 
       # macOS Python 2.7 build
       - ${{ if eq( parameters.has_python_27_tests, true ) }}:
@@ -159,6 +158,7 @@ jobs:
           # Force UI tests off for platforms that don't support them yet.
           has_ui_tests: true
           has_unit_tests: ${{ parameters.has_unit_tests }}
+          ui_automation_ref: merging-from-git-autodesk
 
       # Windows python 3.9 build
       - template: run-tests-with.yml

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -168,7 +168,7 @@ jobs:
           python_version: 3.9
           job_name: "Windows Python 3.9"
           # pass through all parameters
-          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          extra_test_dependencies: [Qt.py, comtypes]
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}
@@ -176,6 +176,7 @@ jobs:
           # Force UI tests off for platforms that don't support them yet.
           has_ui_tests: true
           has_unit_tests: ${{ parameters.has_unit_tests }}
+          ui_automation_ref: merging-from-git-autodesk
 
       # macOS Python 3.9 build
       - template: run-tests-with.yml

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -147,7 +147,7 @@ jobs:
       # Windows Python 3.7 build
       - template: run-tests-with.yml
         parameters:
-          image_name: 'windows-2019'
+          image_name: 'windows-2022 '
           qt_wrapper: PySide2==5.14.1
           python_version: 3.7
           job_name: "Windows Python 3.7"
@@ -165,7 +165,7 @@ jobs:
       # Windows python 3.9 build
       - template: run-tests-with.yml
         parameters:
-          image_name: 'windows-2019'
+          image_name: 'windows-2022 '
           qt_wrapper: PySide2==5.15.2
           python_version: 3.9
           job_name: "Windows Python 3.9"

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -150,7 +150,7 @@ jobs:
           python_version: 3.7
           job_name: "Windows Python 3.7"
           # pass through all parameters
-          extra_test_dependencies: [Qt.py, comtypes]
+          extra_test_dependencies: [Qt.py, comtypes, git+https://github.com/shotgunsoftware/mpas-ma@merging-from-git-autodesk#egg=MA]
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}

--- a/tests/test_ui_automation.py
+++ b/tests/test_ui_automation.py
@@ -18,7 +18,8 @@ if __name__ == "__main__":
         try:
             import MA.UI  # noqa
         except Exception as e:
-            print(str(e))
+            err_tuple = sys.exc_info()
+            print(f"{err_tuple!r}")
     else:
         # Other platforms should not.
         try:

--- a/tests/test_ui_automation.py
+++ b/tests/test_ui_automation.py
@@ -15,7 +15,10 @@ if __name__ == "__main__":
     # Windows & Python 2.7 builds should be able to import
     # the automation code since it should have been cloned.
     if sys.platform == "win32":
-        import MA.UI  # noqa
+        try:
+            import MA.UI  # noqa
+        except Exception as e:
+            print(str(e))
     else:
         # Other platforms should not.
         try:

--- a/tests/test_ui_automation.py
+++ b/tests/test_ui_automation.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
 
     # Windows & Python 2.7 builds should be able to import
     # the automation code since it should have been cloned.
-    if sys.version_info[0] == 2 and sys.platform == "win32":
+    if sys.platform == "win32":
         import MA.UI  # noqa
     else:
         # Other platforms should not.

--- a/tests/test_ui_automation.py
+++ b/tests/test_ui_automation.py
@@ -20,6 +20,8 @@ if __name__ == "__main__":
         except Exception as e:
             err_tuple = sys.exc_info()
             print(f"{err_tuple!r}")
+        else:
+            print("Successfully imported!")
     else:
         # Other platforms should not.
         try:


### PR DESCRIPTION
- Resolves #29 
- `PYTHONPATH=../ui_automation` is not really needed because we're installing the MA module with pip.
- Introduces `ui_automation_ref` parameter to select the commit/branch/tag for the ui automation repo.
- Forces install `comtypes==1.1.14` since this version is compatible with the ui automation framework.
- Adds `-s` to `pytest` to enable standard output on Azure
- Tests import `MA` module
