### PR TITLE
SG-30863 Fix XML coverage reporting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@
   - id: trailing-whitespace
 # Leave black at the bottom so all touchups are done before it is run.
 - repo: https://github.com/ambv/black
-  rev: stable
+  rev: 23.7.0
   hooks:
   - id: black
     language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 # Styles the code properly
 # List of super useful formatters.
+repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.2.3
   hooks:

--- a/internal/code-style-validation.yml
+++ b/internal/code-style-validation.yml
@@ -25,8 +25,8 @@ jobs:
   # Use Python 3 for validating the code.
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
-    displayName: Use Python 3.7
+      versionSpec: '3.9'
+    displayName: Use Python 3.9
 
   - template: pip-install-packages.yml
     parameters:

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -123,7 +123,7 @@ jobs:
   # as "coverage combine" will combine all coverage files that match .coverage.*.
   - bash: |
       (test -e .coveragerc && echo ".coveragerc was found." ) || ((python -c "print('[run]\nsource=.\nomit=\n    tests/*\n[report]\n\nexclude_lines =\n    raise NotImplementedError')" > .coveragerc) && echo "Generated .coveragerc")
-      PYTHONPATH=../ui_automation COVERAGE_FILE=.coverage.tests python -m pytest tests --cov -vv
+      PYTHONPATH=../ui_automation COVERAGE_FILE=.coverage.tests python -m pytest tests --cov --cov-report xml -vv
     # These environment variables need to be set so Linux runs can connect
     # to xvfb and to have complete logging. Each test logging output will
     # be captured by pytest and displayed on failure.


### PR DESCRIPTION
Finally removed the warning

![image](https://github.com/shotgunsoftware/tk-ci-tools/assets/123113322/f1f1ec1d-1b3d-4cb2-93cd-c3a8af2b2e6f)

Tested on: 
- https://github.com/shotgunsoftware/tk-multi-loader2/pull/107
- https://github.com/shotgunsoftware/tk-core/pull/911

Code Coverage is now populated on Azure Pipelines

![image](https://github.com/shotgunsoftware/tk-ci-tools/assets/123113322/8dff591c-2445-4752-85cd-ceb4686e624b)

## Additional Changes
- per https://github.com/psf/black/issues/420, do not use a mutable revision for Black.
- pre-commit config migrated per https://github.com/pre-commit/pre-commit/pull/2656