### PR TITLE
Point to the master branch when running the cloning step for tk-ci-tools.

### DIFF
--- a/build-pipeline.yml
+++ b/build-pipeline.yml
@@ -75,7 +75,7 @@ parameters:
   # Git ref of tk-ci-tools to use.
   - name: tk_ci_tools_ref
     type: string
-    default: SG-31854_Update_Build_ResourcesSh_Scripts_To_Prevent_Making_Invisible_Changes_To_All_Png_Files
+    default: master
 
 # This build pipeline will validate the code style and our test suite on
 # multiple platforms.


### PR DESCRIPTION
Point to the master branch when running the cloning tk-ci-tools step. This reference is used by the Resources validation job.