### PR TITLE
Standardize PySide2 wrapper version for 3.7

### DIFF
--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -72,7 +72,6 @@ jobs:
       - template: run-tests-with.yml
         parameters:
           image_name: 'ubuntu-22.04'
-          qt_wrapper: PySide2==5.14.1
           python_version: 3.7
           job_name: "Linux"
           # pass through all parameters
@@ -86,7 +85,6 @@ jobs:
       - template: run-tests-with.yml
         parameters:
           image_name: 'macos-12'
-          qt_wrapper: PySide2==5.14.1
           python_version: 3.7
           job_name: "macOS"
           # pass through all parameters.
@@ -100,7 +98,6 @@ jobs:
       - template: run-tests-with.yml
         parameters:
           image_name: 'windows-2022'
-          qt_wrapper: PySide2==5.14.1
           python_version: 3.7
           job_name: "Windows"
           # pass through all parameters


### PR DESCRIPTION
No need to specify PySide2 version since we already have a default value on [run-tests-with.yml](https://github.com/shotgunsoftware/tk-ci-tools/blob/master/internal/run-tests-with.yml#L15).

Currently, this is producing some flaky behavior when installing python packages on macOS.