### PR TITLE
SG-34462 Test CI with Python 3.11

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,14 +28,9 @@ pr:
 variables:
 - group: deploy-secrets
 
-# Invoke the build pipeline template with Qt.py has an extra dependency so
-# the tests can run properly.
 jobs:
 - template: build-pipeline.yml
   parameters:
-    # There's a test inside this repo that requires Qt.py
-    extra_test_dependencies:
-    - Qt.py
     # This has the side effect that it ensures we can clone the UI automation
     # repo with the SSH key
     has_ui_tests: true

--- a/internal/code-style-validation.yml
+++ b/internal/code-style-validation.yml
@@ -25,8 +25,8 @@ jobs:
   # Use Python 3 for validating the code.
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.9'
-    displayName: Use Python 3.9
+      versionSpec: '3.10'
+    displayName: Use Python 3.10
 
   - template: pip-install-packages.yml
     parameters:

--- a/internal/code-style-validation.yml
+++ b/internal/code-style-validation.yml
@@ -25,13 +25,13 @@ jobs:
   # Use Python 3 for validating the code.
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.10'
-    displayName: Use Python 3.10
+      versionSpec: '3.11'
+    displayName: Use Python 3.11
 
   - template: pip-install-packages.yml
     parameters:
       packages:
-      - PySide2
+      - PySide6==6.6.1
       - pre-commit
       - git+https://github.com/shotgunsoftware/tk-toolchain.git@${{ parameters.tk_toolchain_ref }}#egg=tk-toolchain
 

--- a/internal/code-style-validation.yml
+++ b/internal/code-style-validation.yml
@@ -25,13 +25,13 @@ jobs:
   # Use Python 3 for validating the code.
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.11'
-    displayName: Use Python 3.11
+      versionSpec: '3.10'
+    displayName: Use Python 3.10
 
   - template: pip-install-packages.yml
     parameters:
       packages:
-      - PySide6==6.6.1
+      - PySide2
       - pre-commit
       - git+https://github.com/shotgunsoftware/tk-toolchain.git@${{ parameters.tk_toolchain_ref }}#egg=tk-toolchain
 
@@ -44,5 +44,6 @@ jobs:
   - bash: pre-commit run --all
     displayName: Validate code
 
+  # Validate documentation with PySide2 and Python 3.10
   - bash: tk-docs-preview --build-only --verbose
     displayName: Validate documentation

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -64,9 +64,6 @@ jobs:
       versionSpec: ${{ parameters.python_version }}
     displayName: Use Python ${{ parameters.python_version }}
 
-  - bash: pip debug --verbose
-    displayName: Debug pip
-  
   - template: pip-install-packages.yml
     parameters:
       packages:

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -69,6 +69,7 @@ jobs:
       packages:
       - ${{ parameters.qt_wrapper }}
       - git+https://github.com/shotgunsoftware/tk-toolchain.git@${{ parameters.tk_toolchain_ref }}#egg=tk-toolchain
+      - attrs==23.2.0  # Fix version for tk-framework-desktopserver
       - pytest-azurepipelines
       # Inserting a parameter that is a list into another list flattens
       # the result instead of nesting it.

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -70,7 +70,6 @@ jobs:
       - ${{ parameters.qt_wrapper }}
       - git+https://github.com/shotgunsoftware/tk-toolchain.git@${{ parameters.tk_toolchain_ref }}#egg=tk-toolchain
       - pytest-azurepipelines
-      - git+https://github.com/pytest-dev/pytest-nunit.git@refs/pull/73/merge  # If this PR is released, then we can remove this line. This supresses deprecation warnings
       # Inserting a parameter that is a list into another list flattens
       # the result instead of nesting it.
       # E.g. given a extra_test_dependencies parameter set to [Qt.py, numpy], the packages

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -70,6 +70,7 @@ jobs:
       - ${{ parameters.qt_wrapper }}
       - git+https://github.com/shotgunsoftware/tk-toolchain.git@${{ parameters.tk_toolchain_ref }}#egg=tk-toolchain
       - pytest-azurepipelines
+      - git+https://github.com/pytest-dev/pytest-nunit.git@refs/pull/73/merge  # If this PR is released, then we can remove this line. This supresses deprecation warnings
       # Inserting a parameter that is a list into another list flattens
       # the result instead of nesting it.
       # E.g. given a extra_test_dependencies parameter set to [Qt.py, numpy], the packages

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -64,6 +64,9 @@ jobs:
       versionSpec: ${{ parameters.python_version }}
     displayName: Use Python ${{ parameters.python_version }}
 
+  - bash: pip debug --verbose
+    displayName: Debug pip
+  
   - template: pip-install-packages.yml
     parameters:
       packages:

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -69,7 +69,6 @@ jobs:
       packages:
       - ${{ parameters.qt_wrapper }}
       - git+https://github.com/shotgunsoftware/tk-toolchain.git@${{ parameters.tk_toolchain_ref }}#egg=tk-toolchain
-      - attrs==23.2.0  # Fix version for tk-framework-desktopserver
       - pytest-azurepipelines
       # Inserting a parameter that is a list into another list flattens
       # the result instead of nesting it.

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -98,7 +98,7 @@ jobs:
         echo ">>> Started Xvfb"
       displayName: Start Xvfb
     # Install libegl1 required for PySide6
-    - bash: apt install libegl1
+    - bash: sudo apt install libegl1
       displayName: Install libegl1
 
   # Repositories using our build pipeline outside of the

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -97,6 +97,9 @@ jobs:
         /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
         echo ">>> Started Xvfb"
       displayName: Start Xvfb
+    # Install libegl1 required for PySide6
+    - bash: apt install libegl1
+      displayName: Install libegl1
 
   # Repositories using our build pipeline outside of the
   # shotgunsoftware organization should not be able to run our UI automation

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -69,127 +69,127 @@ parameters:
 
 jobs:
   - ${{ if eq( parameters.has_unit_tests, true ) }}:
-      # - template: run-tests-with.yml
-      #   parameters:
-      #     image_name: 'ubuntu-22.04'
-      #     python_version: 3.7
-      #     job_name: "Linux"
-      #     # pass through all parameters
-      #     extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-      #     tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-      #     additional_repositories: ${{ parameters.additional_repositories }}
-      #     tk_core_ref: ${{ parameters.tk_core_ref }}
-      #     post_tests_steps: ${{ parameters.post_tests_steps }}
-      #     has_unit_tests: ${{ parameters.has_unit_tests }}
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'ubuntu-22.04'
+          python_version: 3.7
+          job_name: "Linux"
+          # pass through all parameters
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          has_unit_tests: ${{ parameters.has_unit_tests }}
 
-      # - template: run-tests-with.yml
-      #   parameters:
-      #     image_name: 'macos-12'
-      #     python_version: 3.7
-      #     job_name: "macOS"
-      #     # pass through all parameters.
-      #     extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-      #     tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-      #     additional_repositories: ${{ parameters.additional_repositories }}
-      #     tk_core_ref: ${{ parameters.tk_core_ref }}
-      #     post_tests_steps: ${{ parameters.post_tests_steps }}
-      #     has_unit_tests: ${{ parameters.has_unit_tests }}
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'macos-12'
+          python_version: 3.7
+          job_name: "macOS"
+          # pass through all parameters.
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          has_unit_tests: ${{ parameters.has_unit_tests }}
 
-      # - template: run-tests-with.yml
-      #   parameters:
-      #     image_name: 'windows-2022'
-      #     python_version: 3.7
-      #     job_name: "Windows"
-      #     # pass through all parameters
-      #     extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-      #     tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-      #     additional_repositories: ${{ parameters.additional_repositories }}
-      #     tk_core_ref: ${{ parameters.tk_core_ref }}
-      #     post_tests_steps: ${{ parameters.post_tests_steps }}
-      #     has_unit_tests: ${{ parameters.has_unit_tests }}
-      #     ui_automation_ref: ${{ parameters.ui_automation_ref }}
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'windows-2022'
+          python_version: 3.7
+          job_name: "Windows"
+          # pass through all parameters
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          has_unit_tests: ${{ parameters.has_unit_tests }}
+          ui_automation_ref: ${{ parameters.ui_automation_ref }}
 
-      # # ------------------------
-      # - template: run-tests-with.yml
-      #   parameters:
-      #     image_name: 'windows-2022'
-      #     python_version: 3.9
-      #     job_name: "Windows"
-      #     # pass through all parameters
-      #     extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-      #     tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-      #     additional_repositories: ${{ parameters.additional_repositories }}
-      #     tk_core_ref: ${{ parameters.tk_core_ref }}
-      #     post_tests_steps: ${{ parameters.post_tests_steps }}
-      #     has_unit_tests: ${{ parameters.has_unit_tests }}
-      #     ui_automation_ref: ${{ parameters.ui_automation_ref }}
+      # ------------------------
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'windows-2022'
+          python_version: 3.9
+          job_name: "Windows"
+          # pass through all parameters
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          has_unit_tests: ${{ parameters.has_unit_tests }}
+          ui_automation_ref: ${{ parameters.ui_automation_ref }}
 
-      # - template: run-tests-with.yml
-      #   parameters:
-      #     image_name: 'macOS-12'
-      #     python_version: 3.9
-      #     job_name: "macOS"
-      #     # pass through all parameters.
-      #     extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-      #     tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-      #     additional_repositories: ${{ parameters.additional_repositories }}
-      #     tk_core_ref: ${{ parameters.tk_core_ref }}
-      #     post_tests_steps: ${{ parameters.post_tests_steps }}
-      #     has_unit_tests: ${{ parameters.has_unit_tests }}
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'macOS-12'
+          python_version: 3.9
+          job_name: "macOS"
+          # pass through all parameters.
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          has_unit_tests: ${{ parameters.has_unit_tests }}
 
-      # - template: run-tests-with.yml
-      #   parameters:
-      #     image_name: 'ubuntu-22.04'
-      #     python_version: 3.9
-      #     job_name: "Linux"
-      #     # pass through all parameters.
-      #     extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-      #     tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-      #     additional_repositories: ${{ parameters.additional_repositories }}
-      #     tk_core_ref: ${{ parameters.tk_core_ref }}
-      #     post_tests_steps: ${{ parameters.post_tests_steps }}
-      #     has_unit_tests: ${{ parameters.has_unit_tests }}
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'ubuntu-22.04'
+          python_version: 3.9
+          job_name: "Linux"
+          # pass through all parameters.
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          has_unit_tests: ${{ parameters.has_unit_tests }}
 
-      # # -------------------------
-      # - template: run-tests-with.yml
-      #   parameters:
-      #     image_name: 'windows-2022'
-      #     python_version: 3.10
-      #     job_name: "Windows"
-      #     # pass through all parameters
-      #     extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-      #     tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-      #     additional_repositories: ${{ parameters.additional_repositories }}
-      #     tk_core_ref: ${{ parameters.tk_core_ref }}
-      #     post_tests_steps: ${{ parameters.post_tests_steps }}
-      #     has_unit_tests: ${{ parameters.has_unit_tests }}
-      #     ui_automation_ref: ${{ parameters.ui_automation_ref }}
+      # -------------------------
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'windows-2022'
+          python_version: 3.10
+          job_name: "Windows"
+          # pass through all parameters
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          has_unit_tests: ${{ parameters.has_unit_tests }}
+          ui_automation_ref: ${{ parameters.ui_automation_ref }}
 
-      # - template: run-tests-with.yml
-      #   parameters:
-      #     image_name: 'macOS-12'
-      #     python_version: 3.10
-      #     job_name: "macOS"
-      #     # pass through all parameters.
-      #     extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-      #     tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-      #     additional_repositories: ${{ parameters.additional_repositories }}
-      #     tk_core_ref: ${{ parameters.tk_core_ref }}
-      #     post_tests_steps: ${{ parameters.post_tests_steps }}
-      #     has_unit_tests: ${{ parameters.has_unit_tests }}
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'macOS-12'
+          python_version: 3.10
+          job_name: "macOS"
+          # pass through all parameters.
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          has_unit_tests: ${{ parameters.has_unit_tests }}
 
-      # - template: run-tests-with.yml
-      #   parameters:
-      #     image_name: 'ubuntu-22.04'
-      #     python_version: 3.10
-      #     job_name: "Linux"
-      #     # pass through all parameters.
-      #     extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-      #     tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-      #     additional_repositories: ${{ parameters.additional_repositories }}
-      #     tk_core_ref: ${{ parameters.tk_core_ref }}
-      #     post_tests_steps: ${{ parameters.post_tests_steps }}
-      #     has_unit_tests: ${{ parameters.has_unit_tests }}
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'ubuntu-22.04'
+          python_version: 3.10
+          job_name: "Linux"
+          # pass through all parameters.
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          has_unit_tests: ${{ parameters.has_unit_tests }}
 
       # -------------------------
       - template: run-tests-with.yml

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -199,7 +199,7 @@ jobs:
           qt_wrapper: PySide6==6.6.1
           job_name: "Windows"
           # pass through all parameters
-          extra_test_dependencies: PySide6-Essentialss
+          extra_test_dependencies: PySide6-Essentials==6.6.1
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}
@@ -214,7 +214,7 @@ jobs:
           qt_wrapper: PySide6==6.6.1
           job_name: "macOS"
           # pass through all parameters.
-          extra_test_dependencies: PySide6-Essentialss
+          extra_test_dependencies: PySide6-Essentials==6.6.1
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}
@@ -228,7 +228,7 @@ jobs:
           python_version: 3.11
           job_name: "Linux"
           # pass through all parameters.
-          extra_test_dependencies: PySide6-Essentialss
+          extra_test_dependencies: PySide6-Essentials==6.6.1
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -199,7 +199,7 @@ jobs:
           qt_wrapper: PySide6==6.6.1
           job_name: "Windows"
           # pass through all parameters
-          extra_test_dependencies: PyQt6-Qt6==6.6.1
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}
@@ -214,7 +214,7 @@ jobs:
           qt_wrapper: PySide6==6.6.1
           job_name: "macOS"
           # pass through all parameters.
-          extra_test_dependencies: PyQt6-Qt6==6.6.1
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}
@@ -228,7 +228,7 @@ jobs:
           python_version: 3.11
           job_name: "Linux"
           # pass through all parameters.
-          extra_test_dependencies: PyQt6-Qt6==6.6.1
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -196,6 +196,7 @@ jobs:
         parameters:
           image_name: 'windows-2022'
           python_version: 3.11
+          qt_wrapper: PySide6==6.6.1
           job_name: "Windows"
           # pass through all parameters
           extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
@@ -210,6 +211,7 @@ jobs:
         parameters:
           image_name: 'macOS-12'
           python_version: 3.11
+          qt_wrapper: PySide6==6.6.1
           job_name: "macOS"
           # pass through all parameters.
           extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
@@ -222,6 +224,7 @@ jobs:
       - template: run-tests-with.yml
         parameters:
           image_name: 'ubuntu-22.04'
+          qt_wrapper: PySide6==6.6.1
           python_version: 3.11
           job_name: "Linux"
           # pass through all parameters.

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -190,3 +190,44 @@ jobs:
           tk_core_ref: ${{ parameters.tk_core_ref }}
           post_tests_steps: ${{ parameters.post_tests_steps }}
           has_unit_tests: ${{ parameters.has_unit_tests }}
+
+      # -------------------------
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'windows-2022'
+          python_version: 3.11
+          job_name: "Windows"
+          # pass through all parameters
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          has_unit_tests: ${{ parameters.has_unit_tests }}
+          ui_automation_ref: ${{ parameters.ui_automation_ref }}
+
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'macOS-12'
+          python_version: 3.11
+          job_name: "macOS"
+          # pass through all parameters.
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          has_unit_tests: ${{ parameters.has_unit_tests }}
+
+      - template: run-tests-with.yml
+        parameters:
+          image_name: 'ubuntu-22.04'
+          python_version: 3.11
+          job_name: "Linux"
+          # pass through all parameters.
+          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+          additional_repositories: ${{ parameters.additional_repositories }}
+          tk_core_ref: ${{ parameters.tk_core_ref }}
+          post_tests_steps: ${{ parameters.post_tests_steps }}
+          has_unit_tests: ${{ parameters.has_unit_tests }}

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -199,7 +199,7 @@ jobs:
           qt_wrapper: PySide6==6.6.1
           job_name: "Windows"
           # pass through all parameters
-          extra_test_dependencies: PySide6-Essentials==6.6.1
+          extra_test_dependencies: PyQt6-Qt6==6.6.1
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}
@@ -214,7 +214,7 @@ jobs:
           qt_wrapper: PySide6==6.6.1
           job_name: "macOS"
           # pass through all parameters.
-          extra_test_dependencies: PySide6-Essentials==6.6.1
+          extra_test_dependencies: PyQt6-Qt6==6.6.1
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}
@@ -228,7 +228,7 @@ jobs:
           python_version: 3.11
           job_name: "Linux"
           # pass through all parameters.
-          extra_test_dependencies: PySide6-Essentials==6.6.1
+          extra_test_dependencies: PyQt6-Qt6==6.6.1
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -199,7 +199,7 @@ jobs:
           qt_wrapper: PySide6==6.6.1
           job_name: "Windows"
           # pass through all parameters
-          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          extra_test_dependencies: pyqt6-tools
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}
@@ -214,7 +214,7 @@ jobs:
           qt_wrapper: PySide6==6.6.1
           job_name: "macOS"
           # pass through all parameters.
-          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          extra_test_dependencies: pyqt6-tools
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}
@@ -228,7 +228,7 @@ jobs:
           python_version: 3.11
           job_name: "Linux"
           # pass through all parameters.
-          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+          extra_test_dependencies: pyqt6-tools
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -69,127 +69,127 @@ parameters:
 
 jobs:
   - ${{ if eq( parameters.has_unit_tests, true ) }}:
-      - template: run-tests-with.yml
-        parameters:
-          image_name: 'ubuntu-22.04'
-          python_version: 3.7
-          job_name: "Linux"
-          # pass through all parameters
-          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-          additional_repositories: ${{ parameters.additional_repositories }}
-          tk_core_ref: ${{ parameters.tk_core_ref }}
-          post_tests_steps: ${{ parameters.post_tests_steps }}
-          has_unit_tests: ${{ parameters.has_unit_tests }}
+      # - template: run-tests-with.yml
+      #   parameters:
+      #     image_name: 'ubuntu-22.04'
+      #     python_version: 3.7
+      #     job_name: "Linux"
+      #     # pass through all parameters
+      #     extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+      #     tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+      #     additional_repositories: ${{ parameters.additional_repositories }}
+      #     tk_core_ref: ${{ parameters.tk_core_ref }}
+      #     post_tests_steps: ${{ parameters.post_tests_steps }}
+      #     has_unit_tests: ${{ parameters.has_unit_tests }}
 
-      - template: run-tests-with.yml
-        parameters:
-          image_name: 'macos-12'
-          python_version: 3.7
-          job_name: "macOS"
-          # pass through all parameters.
-          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-          additional_repositories: ${{ parameters.additional_repositories }}
-          tk_core_ref: ${{ parameters.tk_core_ref }}
-          post_tests_steps: ${{ parameters.post_tests_steps }}
-          has_unit_tests: ${{ parameters.has_unit_tests }}
+      # - template: run-tests-with.yml
+      #   parameters:
+      #     image_name: 'macos-12'
+      #     python_version: 3.7
+      #     job_name: "macOS"
+      #     # pass through all parameters.
+      #     extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+      #     tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+      #     additional_repositories: ${{ parameters.additional_repositories }}
+      #     tk_core_ref: ${{ parameters.tk_core_ref }}
+      #     post_tests_steps: ${{ parameters.post_tests_steps }}
+      #     has_unit_tests: ${{ parameters.has_unit_tests }}
 
-      - template: run-tests-with.yml
-        parameters:
-          image_name: 'windows-2022'
-          python_version: 3.7
-          job_name: "Windows"
-          # pass through all parameters
-          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-          additional_repositories: ${{ parameters.additional_repositories }}
-          tk_core_ref: ${{ parameters.tk_core_ref }}
-          post_tests_steps: ${{ parameters.post_tests_steps }}
-          has_unit_tests: ${{ parameters.has_unit_tests }}
-          ui_automation_ref: ${{ parameters.ui_automation_ref }}
+      # - template: run-tests-with.yml
+      #   parameters:
+      #     image_name: 'windows-2022'
+      #     python_version: 3.7
+      #     job_name: "Windows"
+      #     # pass through all parameters
+      #     extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+      #     tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+      #     additional_repositories: ${{ parameters.additional_repositories }}
+      #     tk_core_ref: ${{ parameters.tk_core_ref }}
+      #     post_tests_steps: ${{ parameters.post_tests_steps }}
+      #     has_unit_tests: ${{ parameters.has_unit_tests }}
+      #     ui_automation_ref: ${{ parameters.ui_automation_ref }}
 
-      # ------------------------
-      - template: run-tests-with.yml
-        parameters:
-          image_name: 'windows-2022'
-          python_version: 3.9
-          job_name: "Windows"
-          # pass through all parameters
-          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-          additional_repositories: ${{ parameters.additional_repositories }}
-          tk_core_ref: ${{ parameters.tk_core_ref }}
-          post_tests_steps: ${{ parameters.post_tests_steps }}
-          has_unit_tests: ${{ parameters.has_unit_tests }}
-          ui_automation_ref: ${{ parameters.ui_automation_ref }}
+      # # ------------------------
+      # - template: run-tests-with.yml
+      #   parameters:
+      #     image_name: 'windows-2022'
+      #     python_version: 3.9
+      #     job_name: "Windows"
+      #     # pass through all parameters
+      #     extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+      #     tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+      #     additional_repositories: ${{ parameters.additional_repositories }}
+      #     tk_core_ref: ${{ parameters.tk_core_ref }}
+      #     post_tests_steps: ${{ parameters.post_tests_steps }}
+      #     has_unit_tests: ${{ parameters.has_unit_tests }}
+      #     ui_automation_ref: ${{ parameters.ui_automation_ref }}
 
-      - template: run-tests-with.yml
-        parameters:
-          image_name: 'macOS-12'
-          python_version: 3.9
-          job_name: "macOS"
-          # pass through all parameters.
-          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-          additional_repositories: ${{ parameters.additional_repositories }}
-          tk_core_ref: ${{ parameters.tk_core_ref }}
-          post_tests_steps: ${{ parameters.post_tests_steps }}
-          has_unit_tests: ${{ parameters.has_unit_tests }}
+      # - template: run-tests-with.yml
+      #   parameters:
+      #     image_name: 'macOS-12'
+      #     python_version: 3.9
+      #     job_name: "macOS"
+      #     # pass through all parameters.
+      #     extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+      #     tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+      #     additional_repositories: ${{ parameters.additional_repositories }}
+      #     tk_core_ref: ${{ parameters.tk_core_ref }}
+      #     post_tests_steps: ${{ parameters.post_tests_steps }}
+      #     has_unit_tests: ${{ parameters.has_unit_tests }}
 
-      - template: run-tests-with.yml
-        parameters:
-          image_name: 'ubuntu-22.04'
-          python_version: 3.9
-          job_name: "Linux"
-          # pass through all parameters.
-          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-          additional_repositories: ${{ parameters.additional_repositories }}
-          tk_core_ref: ${{ parameters.tk_core_ref }}
-          post_tests_steps: ${{ parameters.post_tests_steps }}
-          has_unit_tests: ${{ parameters.has_unit_tests }}
+      # - template: run-tests-with.yml
+      #   parameters:
+      #     image_name: 'ubuntu-22.04'
+      #     python_version: 3.9
+      #     job_name: "Linux"
+      #     # pass through all parameters.
+      #     extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+      #     tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+      #     additional_repositories: ${{ parameters.additional_repositories }}
+      #     tk_core_ref: ${{ parameters.tk_core_ref }}
+      #     post_tests_steps: ${{ parameters.post_tests_steps }}
+      #     has_unit_tests: ${{ parameters.has_unit_tests }}
 
-      # -------------------------
-      - template: run-tests-with.yml
-        parameters:
-          image_name: 'windows-2022'
-          python_version: 3.10
-          job_name: "Windows"
-          # pass through all parameters
-          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-          additional_repositories: ${{ parameters.additional_repositories }}
-          tk_core_ref: ${{ parameters.tk_core_ref }}
-          post_tests_steps: ${{ parameters.post_tests_steps }}
-          has_unit_tests: ${{ parameters.has_unit_tests }}
-          ui_automation_ref: ${{ parameters.ui_automation_ref }}
+      # # -------------------------
+      # - template: run-tests-with.yml
+      #   parameters:
+      #     image_name: 'windows-2022'
+      #     python_version: 3.10
+      #     job_name: "Windows"
+      #     # pass through all parameters
+      #     extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+      #     tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+      #     additional_repositories: ${{ parameters.additional_repositories }}
+      #     tk_core_ref: ${{ parameters.tk_core_ref }}
+      #     post_tests_steps: ${{ parameters.post_tests_steps }}
+      #     has_unit_tests: ${{ parameters.has_unit_tests }}
+      #     ui_automation_ref: ${{ parameters.ui_automation_ref }}
 
-      - template: run-tests-with.yml
-        parameters:
-          image_name: 'macOS-12'
-          python_version: 3.10
-          job_name: "macOS"
-          # pass through all parameters.
-          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-          additional_repositories: ${{ parameters.additional_repositories }}
-          tk_core_ref: ${{ parameters.tk_core_ref }}
-          post_tests_steps: ${{ parameters.post_tests_steps }}
-          has_unit_tests: ${{ parameters.has_unit_tests }}
+      # - template: run-tests-with.yml
+      #   parameters:
+      #     image_name: 'macOS-12'
+      #     python_version: 3.10
+      #     job_name: "macOS"
+      #     # pass through all parameters.
+      #     extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+      #     tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+      #     additional_repositories: ${{ parameters.additional_repositories }}
+      #     tk_core_ref: ${{ parameters.tk_core_ref }}
+      #     post_tests_steps: ${{ parameters.post_tests_steps }}
+      #     has_unit_tests: ${{ parameters.has_unit_tests }}
 
-      - template: run-tests-with.yml
-        parameters:
-          image_name: 'ubuntu-22.04'
-          python_version: 3.10
-          job_name: "Linux"
-          # pass through all parameters.
-          extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
-          tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
-          additional_repositories: ${{ parameters.additional_repositories }}
-          tk_core_ref: ${{ parameters.tk_core_ref }}
-          post_tests_steps: ${{ parameters.post_tests_steps }}
-          has_unit_tests: ${{ parameters.has_unit_tests }}
+      # - template: run-tests-with.yml
+      #   parameters:
+      #     image_name: 'ubuntu-22.04'
+      #     python_version: 3.10
+      #     job_name: "Linux"
+      #     # pass through all parameters.
+      #     extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
+      #     tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
+      #     additional_repositories: ${{ parameters.additional_repositories }}
+      #     tk_core_ref: ${{ parameters.tk_core_ref }}
+      #     post_tests_steps: ${{ parameters.post_tests_steps }}
+      #     has_unit_tests: ${{ parameters.has_unit_tests }}
 
       # -------------------------
       - template: run-tests-with.yml

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -199,7 +199,7 @@ jobs:
           qt_wrapper: PySide6==6.6.1
           job_name: "Windows"
           # pass through all parameters
-          extra_test_dependencies: pyqt6-tools
+          extra_test_dependencies: PySide6-Essentialss
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}
@@ -214,7 +214,7 @@ jobs:
           qt_wrapper: PySide6==6.6.1
           job_name: "macOS"
           # pass through all parameters.
-          extra_test_dependencies: pyqt6-tools
+          extra_test_dependencies: PySide6-Essentialss
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}
@@ -228,7 +228,7 @@ jobs:
           python_version: 3.11
           job_name: "Linux"
           # pass through all parameters.
-          extra_test_dependencies: pyqt6-tools
+          extra_test_dependencies: PySide6-Essentialss
           tk_toolchain_ref: ${{ parameters.tk_toolchain_ref }}
           additional_repositories: ${{ parameters.additional_repositories }}
           tk_core_ref: ${{ parameters.tk_core_ref }}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -10,15 +10,19 @@
 
 import sys
 
-from sgtk.platform.qt import QtGui
+# We don't have access to sgtk. Import directly from the environment.
+try:
+    from PySide2 import QtWidgets  # noqa
+except ImportError:
+    from PySide6 import QtWidgets  # noqa
 
 
 def test_qt():
     """
     Ensure we can show a Qt dialog on Azure-Pipelines and interact with it.
     """
-    app = QtGui.QApplication(sys.argv)
-    button = QtGui.QPushButton("Hello World")
+    app = QtWidgets.QApplication(sys.argv)
+    button = QtWidgets.QPushButton("Hello World")
     button.show()
     app.processEvents()
     button.close()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -11,9 +11,9 @@
 import sys
 
 try:
-    import PySide2  # noqa
+    from PySide2 import QtWidgets  # noqa
 except ImportError:
-    import PySide6  # noqa
+    from PySide6 import QtWidgets  # noqa
 
 
 def test_qt():

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -10,8 +10,10 @@
 
 import sys
 
-# Qt.py should have been installed by the build pipeline.
-from Qt import QtWidgets
+try:
+    import PySide2  # noqa
+except ImportError:
+    import PySide6  # noqa
 
 
 def test_qt():

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -10,18 +10,15 @@
 
 import sys
 
-try:
-    from PySide2 import QtWidgets  # noqa
-except ImportError:
-    from PySide6 import QtWidgets  # noqa
+from sgtk.platform.qt import QtGui
 
 
 def test_qt():
     """
     Ensure we can show a Qt dialog on Azure-Pipelines and interact with it.
     """
-    app = QtWidgets.QApplication(sys.argv)
-    button = QtWidgets.QPushButton("Hello World")
+    app = QtGui.QApplication(sys.argv)
+    button = QtGui.QPushButton("Hello World")
     button.show()
     app.processEvents()
     button.close()


### PR DESCRIPTION
- Use Python 3.10 and PySide2 to test documentation build
- Use PySide6 with Python 3.11
- Fix unit test to use PySide instead of Qt.py