### PR TITLE
SG-36012 Fix codecov version to v0.7.3

### DIFF
--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -159,7 +159,7 @@ jobs:
           # We have an <path-to-the-repo>/(builtin) and <path-to-the-repo>/pyscript entries in the coverage for which the xml
           # genearte would generate errors otherwise since these are not actual source files
           python -m coverage xml -i
-          curl -Os https://uploader.codecov.io/latest/macos/codecov
+          curl -Os https://uploader.codecov.io/v0.7.3/macos/codecov
           chmod +x codecov
           ./codecov
         displayName: Upload code coverage


### PR DESCRIPTION
`latest` version doesn't support intel architecture. More details in issue https://github.com/codecov/uploader/issues/1687