### PR TITLE
Install tk-toolchain from zip to improve speed and prevent issues with PIP

### DIFF
--- a/internal/code-style-validation.yml
+++ b/internal/code-style-validation.yml
@@ -33,7 +33,7 @@ jobs:
       packages:
       - PySide2
       - pre-commit
-      - https://github.com/shotgunsoftware/tk-toolchain/archive/{{ parameters.tk_toolchain_ref }}.zip
+      - https://github.com/shotgunsoftware/tk-toolchain/archive/${{ parameters.tk_toolchain_ref }}.zip
 
   - template: clone-repositories.yml
     parameters:

--- a/internal/code-style-validation.yml
+++ b/internal/code-style-validation.yml
@@ -33,7 +33,7 @@ jobs:
       packages:
       - PySide2
       - pre-commit
-      - git+https://github.com/shotgunsoftware/tk-toolchain.git@${{ parameters.tk_toolchain_ref }}#egg=tk-toolchain
+      - https://github.com/shotgunsoftware/tk-toolchain/archive/{{ parameters.tk_toolchain_ref }}.zip
 
   - template: clone-repositories.yml
     parameters:

--- a/internal/code-style-validation.yml
+++ b/internal/code-style-validation.yml
@@ -33,7 +33,7 @@ jobs:
       packages:
       - PySide2
       - pre-commit
-      - https://github.com/shotgunsoftware/tk-toolchain/archive/${{ parameters.tk_toolchain_ref }}.zip
+      - tk-toolchain @ https://github.com/shotgunsoftware/tk-toolchain/archive/${{ parameters.tk_toolchain_ref }}.zip
 
   - template: clone-repositories.yml
     parameters:

--- a/internal/code-style-validation.yml
+++ b/internal/code-style-validation.yml
@@ -33,7 +33,7 @@ jobs:
       packages:
       - PySide2
       - pre-commit
-      - tk-toolchain @ https://github.com/shotgunsoftware/tk-toolchain/archive/${{ parameters.tk_toolchain_ref }}.zip
+      - https://github.com/shotgunsoftware/tk-toolchain/archive/${{ parameters.tk_toolchain_ref }}.zip
 
   - template: clone-repositories.yml
     parameters:

--- a/internal/release.yml
+++ b/internal/release.yml
@@ -44,7 +44,7 @@ jobs:
     - template: pip-install-packages.yml
       parameters:
         packages:
-        - https://github.com/shotgunsoftware/tk-toolchain/archive/${{ parameters.tk_toolchain_ref }}.zip
+        - tk-toolchain @ https://github.com/shotgunsoftware/tk-toolchain/archive/${{ parameters.tk_toolchain_ref }}.zip
 
     # Updates the basic, default2 and flame configs
     - template: "update-configuration.yml"

--- a/internal/release.yml
+++ b/internal/release.yml
@@ -44,7 +44,7 @@ jobs:
     - template: pip-install-packages.yml
       parameters:
         packages:
-        - https://github.com/shotgunsoftware/tk-toolchain/archive/{{ parameters.tk_toolchain_ref }}.zip
+        - https://github.com/shotgunsoftware/tk-toolchain/archive/${{ parameters.tk_toolchain_ref }}.zip
 
     # Updates the basic, default2 and flame configs
     - template: "update-configuration.yml"

--- a/internal/release.yml
+++ b/internal/release.yml
@@ -44,7 +44,7 @@ jobs:
     - template: pip-install-packages.yml
       parameters:
         packages:
-        - git+https://github.com/shotgunsoftware/tk-toolchain.git@${{ parameters.tk_toolchain_ref }}#egg=tk-toolchain
+        - https://github.com/shotgunsoftware/tk-toolchain/archive/{{ parameters.tk_toolchain_ref }}.zip
 
     # Updates the basic, default2 and flame configs
     - template: "update-configuration.yml"

--- a/internal/release.yml
+++ b/internal/release.yml
@@ -44,7 +44,7 @@ jobs:
     - template: pip-install-packages.yml
       parameters:
         packages:
-        - tk-toolchain @ https://github.com/shotgunsoftware/tk-toolchain/archive/${{ parameters.tk_toolchain_ref }}.zip
+        - https://github.com/shotgunsoftware/tk-toolchain/archive/${{ parameters.tk_toolchain_ref }}.zip
 
     # Updates the basic, default2 and flame configs
     - template: "update-configuration.yml"

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -75,6 +75,7 @@ jobs:
       - ${{ parameters.extra_test_dependencies }}
 
   - script: |
+      pip --version
       pip list
     displayName: Check installed packages
 

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -61,7 +61,7 @@ jobs:
     parameters:
       packages:
       - ${{ parameters.qt_wrapper }}
-      - https://github.com/shotgunsoftware/tk-toolchain/archive/${{ parameters.tk_toolchain_ref }}.zip
+      - tk-toolchain @ https://github.com/shotgunsoftware/tk-toolchain/archive/${{ parameters.tk_toolchain_ref }}.zip
       - pytest-azurepipelines
       # Inserting a parameter that is a list into another list flattens
       # the result instead of nesting it.

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -61,7 +61,7 @@ jobs:
     parameters:
       packages:
       - ${{ parameters.qt_wrapper }}
-      - https://github.com/shotgunsoftware/tk-toolchain/archive/{{ parameters.tk_toolchain_ref }}.zip
+      - https://github.com/shotgunsoftware/tk-toolchain/archive/${{ parameters.tk_toolchain_ref }}.zip
       - pytest-azurepipelines
       # Inserting a parameter that is a list into another list flattens
       # the result instead of nesting it.

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -74,6 +74,10 @@ jobs:
       # - numpy
       - ${{ parameters.extra_test_dependencies }}
 
+  - script: |
+      pip list
+    displayName: Check installed packages
+
   - template: clone-repositories.yml
     parameters:
       repositories:

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -61,7 +61,7 @@ jobs:
     parameters:
       packages:
       - ${{ parameters.qt_wrapper }}
-      - git+https://github.com/shotgunsoftware/tk-toolchain.git@${{ parameters.tk_toolchain_ref }}#egg=tk-toolchain
+      - https://github.com/shotgunsoftware/tk-toolchain/archive/{{ parameters.tk_toolchain_ref }}.zip
       - pytest-azurepipelines
       # Inserting a parameter that is a list into another list flattens
       # the result instead of nesting it.

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -61,7 +61,7 @@ jobs:
     parameters:
       packages:
       - ${{ parameters.qt_wrapper }}
-      - tk-toolchain @ https://github.com/shotgunsoftware/tk-toolchain/archive/${{ parameters.tk_toolchain_ref }}.zip
+      - https://github.com/shotgunsoftware/tk-toolchain/archive/${{ parameters.tk_toolchain_ref }}.zip
       - pytest-azurepipelines
       # Inserting a parameter that is a list into another list flattens
       # the result instead of nesting it.


### PR DESCRIPTION
Seems like newer versions of PIP dropped some featured (still unknown to us) that prevented from installing the package's dependencies.

Installing tk-toolchain from zip as [pointed out by this answer](https://stackoverflow.com/a/24811490/23617536), improves performance and Azure CI can now run. Example: https://github.com/shotgunsoftware/tk-multi-publish2/pull/196