### PR TITLE
SG-33057 Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ default_language_version:
 # List of super useful formatters.
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.2.3
+  rev: v5.0.0
   hooks:
   # Ensures the code is syntaxically correct
   - id: check-ast
@@ -25,7 +25,7 @@ repos:
   # Removes trailing whitespaces.
   - id: trailing-whitespace
 # Leave black at the bottom so all touchups are done before it is run.
-- repo: https://github.com/ambv/black
-  rev: 23.7.0
+- repo: https://github.com/psf/black
+  rev: 25.1.0
   hooks:
   - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 # Styles the code properly
+
+default_language_version:
+    python: python3
+
 # List of super useful formatters.
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -6,7 +10,6 @@ repos:
   hooks:
   # Ensures the code is syntaxically correct
   - id: check-ast
-    language_version: python3
   # Ensures a file name will resolve on all platform
   - id: check-case-conflict
   # Checks files with the execute bit set have shebangs
@@ -26,4 +29,3 @@ repos:
   rev: 23.7.0
   hooks:
   - id: black
-    language_version: python3

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ You save the following as a starting point at the root of your respository in a 
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+default_language_version:
+    python: python3
+
 # Styles the code properly
 # Exclude the UI files, as they are auto-generated.
 exclude: "ui\/.*py$"
@@ -51,7 +54,6 @@ repos:
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
-      language_version: python3
     # Ensures a file name will resolve on all platform
     - id: check-case-conflict
     # Checks files with the execute bit set have shebangs
@@ -65,12 +67,10 @@ repos:
     # Removes trailing whitespaces.
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
-  - repo: https://github.com/ambv/black
-    rev: 19.10b0
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
     hooks:
     - id: black
-      language_version: python3
-
 ```
 
 ## Azure Pipeline configuration

--- a/internal/code-style-validation.yml
+++ b/internal/code-style-validation.yml
@@ -41,8 +41,8 @@ jobs:
       - name: tk-core
         ref: ${{ parameters.tk_core_ref }}
 
-  - displayName: Update pre-commit hook versions
-    bash: pre-commit autoupdate
+  - bash: pre-commit autoupdate
+    displayName: Update pre-commit hook versions
 
   - bash: pre-commit run --all
     displayName: Validate code

--- a/internal/code-style-validation.yml
+++ b/internal/code-style-validation.yml
@@ -41,6 +41,9 @@ jobs:
       - name: tk-core
         ref: ${{ parameters.tk_core_ref }}
 
+  - displayName: Update pre-commit hook versions
+    bash: pre-commit autoupdate
+
   - bash: pre-commit run --all
     displayName: Validate code
 


### PR DESCRIPTION
- Add `pre-commit autoupdate` call so CI always uses newest hook versions
- Cleanup and update `.pre-commit-config.yaml` file:
  - Update pre-commit-hooks to version `v5.0.0`
  - Update black hook to version `25.1.0`
  - Update black hook URL
  - Use global `default_language_version` instead of individuals `language_version`
- Update `.pre-commit-config.yaml` template accordingly in README file