### PR TITLE
SG-38086 Use PySide6 version to latest

### DIFF
--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -186,7 +186,7 @@ jobs:
         parameters:
           image_name: 'windows-2022'
           python_version: 3.11
-          qt_wrapper: PySide6==6.5.3
+          qt_wrapper: PySide6
           job_name: "Windows"
           # pass through all parameters
           extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
@@ -200,7 +200,7 @@ jobs:
         parameters:
           image_name: 'macOS-14'
           python_version: 3.11
-          qt_wrapper: PySide6==6.5.3
+          qt_wrapper: PySide6
           job_name: "macOS"
           # pass through all parameters.
           extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
@@ -213,7 +213,7 @@ jobs:
       - template: run-tests-with.yml
         parameters:
           image_name: 'ubuntu-22.04'
-          qt_wrapper: PySide6==6.5.3
+          qt_wrapper: PySide6
           python_version: 3.11
           job_name: "Linux"
           # pass through all parameters.

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -186,7 +186,7 @@ jobs:
         parameters:
           image_name: 'windows-2022'
           python_version: 3.11
-          qt_wrapper: PySide6==6.6.1
+          qt_wrapper: PySide6==6.5.3
           job_name: "Windows"
           # pass through all parameters
           extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
@@ -200,7 +200,7 @@ jobs:
         parameters:
           image_name: 'macOS-14'
           python_version: 3.11
-          qt_wrapper: PySide6==6.6.1
+          qt_wrapper: PySide6==6.5.3
           job_name: "macOS"
           # pass through all parameters.
           extra_test_dependencies: ${{ parameters.extra_test_dependencies }}
@@ -213,7 +213,7 @@ jobs:
       - template: run-tests-with.yml
         parameters:
           image_name: 'ubuntu-22.04'
-          qt_wrapper: PySide6==6.6.1
+          qt_wrapper: PySide6==6.5.3
           python_version: 3.11
           job_name: "Linux"
           # pass through all parameters.


### PR DESCRIPTION
Python 3.11 tests require PySide6. However, in CI we were using a PySide6 open source version that probably has bugs that had been fixed lately, causing flaky tests on https://github.com/shotgunsoftware/tk-framework-shotgunutils/pull/164