### PR TITLE
SG-38126 Review and Fixups CI Tests and Code Coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.10%20%7C%203.9-blue.svg)](https://www.python.org/)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/tk-ci-tools?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=39&branchName=master)
+[![Coverage Status](https://codecov.io/gh/shotgunsoftware/tk-ci-tools/branch/master/graph/badge.svg)](https://codecov.io/gh/shotgunsoftware/tk-ci-tools)
 
 # tk-ci-tools
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.10%20%7C%203.9-blue.svg)](https://www.python.org/)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/tk-ci-tools?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=39&branchName=master)
-[![Coverage Status](https://codecov.io/gh/shotgunsoftware/tk-ci-tools/branch/master/graph/badge.svg)](https://codecov.io/gh/shotgunsoftware/tk-ci-tools)
 
 # tk-ci-tools
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,8 +37,6 @@ jobs:
     - name: tk-multi-testing
       ref: azure_test_branch
     - name: tk-framework-qtwidgets
-    # This one shouldn't get cloned.
-    - name: tk-ci-tools
     post_tests_steps:
     # Ensures the Shotgun script credentials can connect to the AppStore.
     - bash: PYTHONPATH=../tk-core/python python tests/test_credentials.py

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -9,51 +9,83 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 parameters:
-  # Name of the virtual machine image to load.
-  image_name: ""
-  # Name of the Qt wrapper to pip install. Should be PySide or PySide2
-  qt_wrapper: ''
-  # Python version to use.
-  python_version: ''
-  codecov_download_url: ''
-  # List of Python packages that need to be pip installed for testing.
-  extra_test_dependencies: []
-  # Pretty name for the OS.
-  os_name: ""
-  # Git ref of tk-toolchain to use.
-  tk_toolchain_ref: master
-  # List of repositories to clone alongside this repository.
-  # To clone the tk-framework-shotgunutils's master branch
-  # and a specific tk-framework-qtwidget ref, you would
-  # set this parameter to the following:
-  # - name: tk-framework-shotgunutils
-  # - name: tk-framework-qtwidgets
-  #   ref: <branch-or-tag>
-  additional_repositories: []
-  # Git ref of tk-core to use.
-  tk_core_ref: master
-  # Post test steps
-  # This is a list of Azure Pipeline steps that will be inserted
-  # right after the tests were run.
-  # If you wanted to run a non-standard suite of test as an extra
-  # you would specify post_tests_steps as:
-  # post_tests_steps:
-  # - bash: do_something
-  # - bash: do_something_else
-  post_tests_steps: []
+  # Using the most formal way of defining parameters so we don't define a
+  # default value for mandatory parameters. This way, CI will fail if we forget
+  # to pass it when invoking the template.
+
+  # Mandatory parameters first
+
+  - name: codecov_download_url
+    type: string
+
+  - name: image_name
+    type: string
+    # Name of the virtual machine image to load.
+
+  - name: os_name
+    type: string
+    # Pretty name for the OS.
+
+  - name: python_version
+    type: string
+    # Python version to use.
+
+  - name: qt_wrapper
+    type: string
+    # Name of the Qt wrapper to pip install. Should be PySide or PySide2
+
+  # Then optional parameters
+
+  - name: additional_repositories
+    type: object
+    default: []
+    # List of repositories to clone alongside this repository.
+    # To clone the tk-framework-shotgunutils's master branch
+    # and a specific tk-framework-qtwidget ref, you would
+    # set this parameter to the following:
+    # - name: tk-framework-shotgunutils
+    # - name: tk-framework-qtwidgets
+    #   ref: <branch-or-tag>
+
+  - name: extra_test_dependencies
+    type: object
+    default: []
+    # List of Python packages that need to be pip installed for testing.
+
+  - name: post_tests_steps
+    type: object
+    default: []
+    # Post test steps
+    # This is a list of Azure Pipeline steps that will be inserted
+    # right after the tests were run.
+    # If you wanted to run a non-standard suite of test as an extra
+    # you would specify post_tests_steps as:
+    # post_tests_steps:
+    # - bash: do_something
+    # - bash: do_something_else
+
+  - name: tk_core_ref
+    type: string
+    default: master
+    # Git ref of tk-core to use.
+
+  - name: tk_toolchain_ref
+    type: string
+    default: master
+    # Git ref of tk-toolchain to use.
 
 jobs:
 - job:
-  displayName: ${{ parameters.os_name }} Python ${{ parameters.python_version }}
+  displayName: ${{ parameters.os_name }} - Python ${{ parameters.python_version }}
   pool:
     vmImage: ${{ parameters.image_name }}
   steps:
 
   # Switch to the right Python Version.
   - task: UsePythonVersion@0
+    displayName: Use Python ${{ parameters.python_version }}
     inputs:
       versionSpec: ${{ parameters.python_version }}
-    displayName: Use Python ${{ parameters.python_version }}
 
   - template: pip-install-packages.yml
     parameters:
@@ -74,10 +106,13 @@ jobs:
       # - numpy
       - ${{ parameters.extra_test_dependencies }}
 
-  - script: |
-      pip --version
-      pip list
+  - task: Bash@3
     displayName: Check installed packages
+    inputs:
+      targetType: inline
+      script: |
+        pip --version
+        pip list
 
   - template: clone-repositories.yml
     parameters:
@@ -89,7 +124,7 @@ jobs:
 
   # We can't use eq(Agent.OS, 'linux') here because template expansion is done
   # before the job is assigned to an agent.
-  - ${{ if contains(parameters.image_name, 'ubuntu') }}:
+  - ${{ if contains(parameters.os_name, 'Linux') }}:
     # Start xvfb on Linux so we can test with a GUI.
     - bash: |
         /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
@@ -117,39 +152,57 @@ jobs:
   # all tests tasks require access to our secrets so they can't be used and the build will
   # fail.
 
-  # Run the tests. The task will create a simple coverage file if one is missing.
-  # It will include all code except for the "tests" folder.
-  - bash: |
-      if [ -e .coveragerc ]; then
-        echo ".coveragerc was found."
-      else
+  - task: Bash@3
+    displayName: Create a simple coverage file if missing
+    # Run the tests. The task will create a simple coverage file if one is missing.
+    # It will include all code except for the "tests" folder.
+    inputs:
+      targetType: inline
+      script: |
+        set -e
+
+        if [ -e .coveragerc ]; then
+          echo ".coveragerc was found."
+          exit 0
+        fi
+
         cat > .coveragerc <<EOF
-      [run]
-      source=.
-      omit=tests/*
-      [report]
-      exclude_lines = raise NotImplementedError
-      EOF
+        [run]
+        source=.
+        omit=tests/*
+        [report]
+        exclude_lines = raise NotImplementedError
+        EOF
+
         echo "Generated .coveragerc"
-      fi
 
-      python -m pytest \
-        tests \
-        --cov \
-        --cov-report xml \
-        --nunit-xml=test-results.xml \
-        --verbose \
-
-    # These environment variables need to be set so Linux runs can connect
-    # to xvfb and to have complete logging. Each test logging output will
-    # be captured by pytest and displayed on failure.
+  - task: Bash@3
+    displayName: Run tests
+    # Run the tests. The task will create a simple coverage file if one is missing.
+    # It will include all code except for the "tests" folder.
+    inputs:
+      targetType: inline
+      script: |
+        python -m pytest tests \
+          --cov \
+          --cov-report xml:coverage.xml \
+          --durations=0 \
+          --nunit-xml=test-results.xml \
+          --verbose \
     env:
-      QT_QPA_PLATFORM: offscreen
-      DISPLAY: ':99.0'
-      TK_DEBUG: 1
+      # Tell Pytest that we're running in a CI environment
       CI: 1
 
-      COVERAGE_FILE: '.coverage.tests'
+      TK_DEBUG: 1
+
+      ${{ if eq(parameters.os_name, 'Linux') }}:
+        # These environment variables need to be set so Linux runs can connect
+        # to xvfb and to have complete logging. Each test logging output will
+        # be captured by pytest and displayed on failure.
+        QT_QPA_PLATFORM: offscreen
+        DISPLAY: ':99.0'
+
+      # COVERAGE_FILE: '.coverage.tests' ## TODO!!!!
       # Note that we're hardcoding the name of the coverage file. This is important
       # as "coverage combine" will combine all coverage files that match .coverage.*.
       # The parameters.post_tests_steps might also produce coeverage files
@@ -160,7 +213,6 @@ jobs:
       TK_TOOLCHAIN_USER_LOGIN: $(sg.ci.human.login)
       TK_TOOLCHAIN_USER_PASSWORD: $(sg.ci.human.password)
       SHOTGUN_TEST_ENTITY_SUFFIX: '$(Agent.Name)'
-    displayName: Run tests
 
   # The post_test_steps list will be flattened into this list of steps.
   - ${{ parameters.post_tests_steps }}
@@ -172,6 +224,7 @@ jobs:
     inputs:
       targetType: inline
       script: |
+        set -e
         python -m coverage combine
 
         python -m coverage xml -i
@@ -182,11 +235,11 @@ jobs:
   - task: PublishTestResults@2
     displayName: Publish test results
     inputs:
-      testResultsFormat: NUnit
-      testResultsFiles: test-results.xml
-      testRunTitle: "${{ parameters.os_name }} - Python ${{ parameters.python_version }}"
       failTaskOnFailureToPublishResults: true
       failTaskOnMissingResultsFile: true
+      testResultsFiles: test-results.xml
+      testResultsFormat: NUnit
+      testRunTitle: "${{ parameters.os_name }} - Python ${{ parameters.python_version }}"
     condition: succeededOrFailed()
 
   - task: PublishCodeCoverageResults@2
@@ -195,17 +248,19 @@ jobs:
       summaryFileLocation: coverage.xml
       failIfCoverageEmpty: true
 
-  # Upload the code coverage result to codecov.io using the binary uploader.
-  # Use flags to identify coverage from each OS/Python combination for proper merging.
-  #
   - task: Bash@3
     displayName: Uploading coverage to Codecov.io
+    # Upload the code coverage result to codecov.io using the binary uploader.
+    # Use flags to identify coverage from each OS/Python combination for proper
+    # merging.
     inputs:
       targetType: inline
       script: |
+        set -e
         curl -Os "${{ parameters.codecov_download_url }}"
         chmod +x codecov
         ./codecov  \
           --file coverage.xml \
           --flags ${{ parameters.os_name }} \
-          --flags Python-${{ parameters.python_version }} \
+          --flags "Python-${{ parameters.python_version }}" \
+          --name "Tested on ${{ parameters.os_name }} with Python ${{ parameters.python_version }}" \

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -15,6 +15,7 @@ parameters:
   qt_wrapper: ''
   # Python version to use.
   python_version: ''
+  codecov_download_url: ''
   # List of Python packages that need to be pip installed for testing.
   extra_test_dependencies: []
   # Pretty name for the OS.
@@ -123,12 +124,12 @@ jobs:
         echo ".coveragerc was found."
       else
         cat > .coveragerc <<EOF
-        [run]
-        source=.
-        omit=tests/*
-        [report]
-        exclude_lines = raise NotImplementedError
-        EOF
+      [run]
+      source=.
+      omit=tests/*
+      [report]
+      exclude_lines = raise NotImplementedError
+      EOF
         echo "Generated .coveragerc"
       fi
 
@@ -202,7 +203,7 @@ jobs:
     inputs:
       targetType: inline
       script: |
-        curl -Os "${{ variables.codecov_download_url }}"
+        curl -Os "${{ parameters.codecov_download_url }}"
         chmod +x codecov
         ./codecov  \
           --file coverage.xml \

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -59,7 +59,9 @@ jobs:
       packages:
       - ${{ parameters.qt_wrapper }}
       - https://github.com/shotgunsoftware/tk-toolchain/archive/${{ parameters.tk_toolchain_ref }}.zip
-      - pytest-azurepipelines
+      - pytest
+      - pytest-cov
+      - pytest-nunit
       # Inserting a parameter that is a list into another list flattens
       # the result instead of nesting it.
       # E.g. given a extra_test_dependencies parameter set to [Qt.py, numpy], the packages
@@ -116,11 +118,27 @@ jobs:
 
   # Run the tests. The task will create a simple coverage file if one is missing.
   # It will include all code except for the "tests" folder.
-  # Note that we're hardcoding the name of the coverage file. This is important
-  # as "coverage combine" will combine all coverage files that match .coverage.*.
   - bash: |
-      (test -e .coveragerc && echo ".coveragerc was found." ) || ((python -c "print('[run]\nsource=.\nomit=\n    tests/*\n[report]\n\nexclude_lines =\n    raise NotImplementedError')" > .coveragerc) && echo "Generated .coveragerc")
-      COVERAGE_FILE=.coverage.tests python -m pytest tests --cov --cov-report xml -vv
+      if [ -e .coveragerc ]; then
+        echo ".coveragerc was found."
+      else
+        cat > .coveragerc <<EOF
+        [run]
+        source=.
+        omit=tests/*
+        [report]
+        exclude_lines = raise NotImplementedError
+        EOF
+        echo "Generated .coveragerc"
+      fi
+
+      python -m pytest \
+        tests \
+        --cov \
+        --cov-report xml \
+        --nunit-xml=test-results.xml \
+        --verbose \
+
     # These environment variables need to be set so Linux runs can connect
     # to xvfb and to have complete logging. Each test logging output will
     # be captured by pytest and displayed on failure.
@@ -129,6 +147,11 @@ jobs:
       DISPLAY: ':99.0'
       TK_DEBUG: 1
       CI: 1
+
+      COVERAGE_FILE=.coverage.tests
+      # Note that we're hardcoding the name of the coverage file. This is important
+      # as "coverage combine" will combine all coverage files that match .coverage.*.
+
       # Allows to connect to a real Shotgun site during a test. Use sparingly to avoid
       # slowing down automation. Using Mockgun is still the best way to have speedy tests.
       TK_TOOLCHAIN_HOST: $(sg.ci.host)
@@ -140,46 +163,47 @@ jobs:
   # The post_test_steps list will be flattened into this list of steps.
   - ${{ parameters.post_tests_steps }}
 
-  # We're done, we can now upload code coverage, but first, we'll have to
+  # We're done testing.. Before we can upload code coverage, we'll have to
   # combine the results.
+  - task: Bash@3
+    displayName: Combine code coverage results
+    inputs:
+      targetType: inline
+      script: |
+        python -m coverage combine
 
-  - ${{ if contains(parameters.image_name, 'ubuntu') }}:
+        python -m coverage xml -i
+      # We need to pass in -i because we had some weird coverage entries for our frameworks and apps (tk-core is not affected)
+      # We have an <path-to-the-repo>/(builtin) and <path-to-the-repo>/pyscript entries in the coverage for which the xml
+      # genearte would generate errors otherwise since these are not actual source files
 
-      - bash: |
-          python -m coverage combine
-          # We need to pass in -i because we had some weird coverage entries for our frameworks and apps (tk-core is not affected)
-          # We have an <path-to-the-repo>/(builtin) and <path-to-the-repo>/pyscript entries in the coverage for which the xml
-          # genearte would generate errors otherwise since these are not actual source files
-          python -m coverage xml -i
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov
-        displayName: Upload code coverage
+  - task: PublishTestResults@2
+    displayName: Publish test results
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: test-results.xml
+      testRunTitle: "${{ parameters.os_name }} - Python ${{ parameters.python_version }}"
+      failTaskOnFailureToPublishResults: true
+      failTaskOnMissingResultsFile: true
+    condition: succeededOrFailed()
 
+  - task: PublishCodeCoverageResults@2
+    displayName: Publish code coverage
+    inputs:
+      summaryFileLocation: coverage.xml
+      failIfCoverageEmpty: true
 
-  - ${{ if contains(parameters.image_name, 'macos') }}:
-
-      - bash: |
-          python -m coverage combine
-          # We need to pass in -i because we had some weird coverage entries for our frameworks and apps (tk-core is not affected)
-          # We have an <path-to-the-repo>/(builtin) and <path-to-the-repo>/pyscript entries in the coverage for which the xml
-          # genearte would generate errors otherwise since these are not actual source files
-          python -m coverage xml -i
-          curl -Os https://uploader.codecov.io/v0.7.3/macos/codecov
-          chmod +x codecov
-          ./codecov
-        displayName: Upload code coverage
-
-
-  - ${{ if contains(parameters.image_name, 'windows') }}:
-
-      - powershell: |
-          python -m coverage combine
-          # We need to pass in -i because we had some weird coverage entries for our frameworks and apps (tk-core is not affected)
-          # We have an <path-to-the-repo>/(builtin) and <path-to-the-repo>/pyscript entries in the coverage for which the xml
-          # genearte would generate errors otherwise since these are not actual source files
-          python -m coverage xml -i
-          $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
-          .\codecov.exe
-        displayName: Upload code coverage
+  # Upload the code coverage result to codecov.io using the binary uploader.
+  # Use flags to identify coverage from each OS/Python combination for proper merging.
+  #
+  - task: Bash@3
+    displayName: Uploading coverage to Codecov.io
+    inputs:
+      targetType: inline
+      script: |
+        curl -Os "${{ variables.codecov_download_url }}"
+        chmod +x codecov
+        ./codecov  \
+          --file coverage.xml \
+          --flags ${{ parameters.os_name }} \
+          --flags Python-${{ parameters.python_version }} \

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -149,8 +149,6 @@ jobs:
       CI: 1
 
       COVERAGE_FILE=.coverage.tests
-      # Note that we're hardcoding the name of the coverage file. This is important
-      # as "coverage combine" will combine all coverage files that match .coverage.*.
 
       # Allows to connect to a real Shotgun site during a test. Use sparingly to avoid
       # slowing down automation. Using Mockgun is still the best way to have speedy tests.
@@ -159,6 +157,8 @@ jobs:
       TK_TOOLCHAIN_USER_PASSWORD: $(sg.ci.human.password)
       SHOTGUN_TEST_ENTITY_SUFFIX: '$(Agent.Name)'
     displayName: Run tests
+    # Note that we're hardcoding the name of the coverage file. This is important
+    # as "coverage combine" will combine all coverage files that match .coverage.*.
 
   # The post_test_steps list will be flattened into this list of steps.
   - ${{ parameters.post_tests_steps }}

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -18,10 +18,6 @@ parameters:
   - name: codecov_download_url
     type: string
 
-  - name: image_name
-    type: string
-    # Name of the virtual machine image to load.
-
   - name: os_name
     type: string
     # Pretty name for the OS.
@@ -33,6 +29,10 @@ parameters:
   - name: qt_wrapper
     type: string
     # Name of the Qt wrapper to pip install. Should be PySide or PySide2
+
+  - name: vm_image
+    type: string
+    # Name of the virtual machine image to load
 
   # Then optional parameters
 
@@ -78,7 +78,7 @@ jobs:
 - job:
   displayName: ${{ parameters.os_name }} - Python ${{ parameters.python_version }}
   pool:
-    vmImage: ${{ parameters.image_name }}
+    vmImage: ${{ parameters.vm_image }}
   steps:
 
   # Switch to the right Python Version.
@@ -178,8 +178,7 @@ jobs:
 
   - task: Bash@3
     displayName: Run tests
-    # Run the tests. The task will create a simple coverage file if one is missing.
-    # It will include all code except for the "tests" folder.
+    # Runs the tests and generates both test report and code coverage
     inputs:
       targetType: inline
       script: |
@@ -190,13 +189,13 @@ jobs:
           --nunit-xml=test-results-main.xml \
           --verbose \
     env:
-      # Tell Pytest that we're running in a CI environment
       CI: 1
+      # Tell Pytest that we're running in a CI environment
 
+      COVERAGE_FILE: '.coverage.main'
       # Note that we're hardcoding the name of the coverage file. This is important
       # as "coverage combine" will combine all coverage files that match .coverage.*.
       # The parameters.post_tests_steps might also produce coeverage files
-      COVERAGE_FILE: '.coverage.main'
 
       ${{ if eq(parameters.os_name, 'Linux') }}:
         # These environment variables need to be set so Linux runs can connect
@@ -263,7 +262,7 @@ jobs:
       targetType: inline
       script: |
         set -e
-        curl -Os "${{ parameters.codecov_download_url }}"
+        curl --remote-name --silent "${{ parameters.codecov_download_url }}"
         chmod +x codecov
         ./codecov  \
           --file coverage.xml \

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -92,8 +92,8 @@ jobs:
       packages:
       - ${{ parameters.qt_wrapper }}
       - https://github.com/shotgunsoftware/tk-toolchain/archive/${{ parameters.tk_toolchain_ref }}.zip
-      - coverage
       - pytest
+      - pytest-cov
       - pytest-nunit
       # Inserting a parameter that is a list into another list flattens
       # the result instead of nesting it.
@@ -169,7 +169,7 @@ jobs:
         cat > .coveragerc <<EOF
         [run]
         source=.
-        omit=tests/*, *shibokensupport/*
+        omit=tests/*
         [report]
         exclude_lines = raise NotImplementedError
         EOF
@@ -183,21 +183,20 @@ jobs:
     inputs:
       targetType: inline
       script: |
-        python -m coverage \
-          run \
-          --data-file=.coverage.main \
-          -m pytest \
-              tests \
-              --durations=0 \
-              --nunit-xml=test-results-main.xml \
-              --verbose \
-    # Note that we're hardcoding the name of the coverage file. This is important
-    # as "coverage combine" will combine all coverage files that match .coverage.*.
-    # The parameters.post_tests_steps might also produce coeverage files
-
+        python -m pytest \
+          tests \
+          --cov \
+          --durations=0 \
+          --nunit-xml=test-results-main.xml \
+          --verbose \
     env:
       # Tell Pytest that we're running in a CI environment
       CI: 1
+
+      # Note that we're hardcoding the name of the coverage file. This is important
+      # as "coverage combine" will combine all coverage files that match .coverage.*.
+      # The parameters.post_tests_steps might also produce coeverage files
+      COVERAGE_FILE: '.coverage.main'
 
       ${{ if eq(parameters.os_name, 'Linux') }}:
         # These environment variables need to be set so Linux runs can connect

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -148,7 +148,10 @@ jobs:
       TK_DEBUG: 1
       CI: 1
 
-      COVERAGE_FILE=.coverage.tests
+      COVERAGE_FILE: .coverage.tests
+      # Note that we're hardcoding the name of the coverage file. This is important
+      # as "coverage combine" will combine all coverage files that match .coverage.*.
+      # The parameters.post_tests_steps might also produce coeverage files
 
       # Allows to connect to a real Shotgun site during a test. Use sparingly to avoid
       # slowing down automation. Using Mockgun is still the best way to have speedy tests.
@@ -157,8 +160,6 @@ jobs:
       TK_TOOLCHAIN_USER_PASSWORD: $(sg.ci.human.password)
       SHOTGUN_TEST_ENTITY_SUFFIX: '$(Agent.Name)'
     displayName: Run tests
-    # Note that we're hardcoding the name of the coverage file. This is important
-    # as "coverage combine" will combine all coverage files that match .coverage.*.
 
   # The post_test_steps list will be flattened into this list of steps.
   - ${{ parameters.post_tests_steps }}

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -244,7 +244,7 @@ jobs:
     inputs:
       failTaskOnFailureToPublishResults: true
       failTaskOnMissingResultsFile: true
-      testResultsFiles: test-results.xml
+      testResultsFiles: test-results*.xml
       testResultsFormat: NUnit
       testRunTitle: "${{ parameters.os_name }} - Python ${{ parameters.python_version }}"
     condition: succeededOrFailed()

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -185,7 +185,6 @@ jobs:
       script: |
         python -m pytest tests \
           --cov \
-          --cov-report xml:coverage.xml \
           --durations=0 \
           --nunit-xml=test-results.xml \
           --verbose \
@@ -193,7 +192,10 @@ jobs:
       # Tell Pytest that we're running in a CI environment
       CI: 1
 
-      TK_DEBUG: 1
+      COVERAGE_FILE: '.coverage.tests'
+      # Note that we're hardcoding the name of the coverage file. This is important
+      # as "coverage combine" will combine all coverage files that match .coverage.*.
+      # The parameters.post_tests_steps might also produce coeverage files
 
       ${{ if eq(parameters.os_name, 'Linux') }}:
         # These environment variables need to be set so Linux runs can connect
@@ -202,10 +204,7 @@ jobs:
         QT_QPA_PLATFORM: offscreen
         DISPLAY: ':99.0'
 
-      # COVERAGE_FILE: '.coverage.tests' ## TODO!!!!
-      # Note that we're hardcoding the name of the coverage file. This is important
-      # as "coverage combine" will combine all coverage files that match .coverage.*.
-      # The parameters.post_tests_steps might also produce coeverage files
+      TK_DEBUG: 1
 
       # Allows to connect to a real Shotgun site during a test. Use sparingly to avoid
       # slowing down automation. Using Mockgun is still the best way to have speedy tests.
@@ -227,10 +226,16 @@ jobs:
         set -e
         python -m coverage combine
 
-        python -m coverage xml -i
+        python -m coverage xml -i -o coverage.xml
       # We need to pass in -i because we had some weird coverage entries for our frameworks and apps (tk-core is not affected)
       # We have an <path-to-the-repo>/(builtin) and <path-to-the-repo>/pyscript entries in the coverage for which the xml
       # genearte would generate errors otherwise since these are not actual source files
+
+  # Explicit call to PublishTestResults@2 and PublishCodeCoverageResults@2 here
+  # instead of relying on pytest-azurepipelines because pytest-azurepipelines
+  # does not seem to be maintained anymore and is still using earlier versions
+  # of the PublishTestResults and PublishCodeCoverageResults Azure Pipelines
+  # jobs.
 
   - task: PublishTestResults@2
     displayName: Publish test results

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -186,7 +186,8 @@ jobs:
         python -m coverage \
           run \
           --data-file=.coverage.main \
-            pytest tests \
+          -m pytest \
+              tests \
               --durations=0 \
               --nunit-xml=test-results-main.xml \
               --verbose \

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -148,7 +148,7 @@ jobs:
       TK_DEBUG: 1
       CI: 1
 
-      COVERAGE_FILE: .coverage.tests
+      COVERAGE_FILE: '.coverage.tests'
       # Note that we're hardcoding the name of the coverage file. This is important
       # as "coverage combine" will combine all coverage files that match .coverage.*.
       # The parameters.post_tests_steps might also produce coeverage files

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -169,7 +169,7 @@ jobs:
         cat > .coveragerc <<EOF
         [run]
         source=.
-        omit=tests/*
+        omit=tests/*, *shibokensupport/*
         [report]
         exclude_lines = raise NotImplementedError
         EOF

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -92,8 +92,8 @@ jobs:
       packages:
       - ${{ parameters.qt_wrapper }}
       - https://github.com/shotgunsoftware/tk-toolchain/archive/${{ parameters.tk_toolchain_ref }}.zip
+      - coverage
       - pytest
-      - pytest-cov
       - pytest-nunit
       # Inserting a parameter that is a list into another list flattens
       # the result instead of nesting it.
@@ -183,19 +183,20 @@ jobs:
     inputs:
       targetType: inline
       script: |
-        python -m pytest tests \
-          --cov \
-          --durations=0 \
-          --nunit-xml=test-results.xml \
-          --verbose \
+        python -m coverage \
+          run \
+          --data-file=.coverage.main \
+            pytest tests \
+              --durations=0 \
+              --nunit-xml=test-results-main.xml \
+              --verbose \
+    # Note that we're hardcoding the name of the coverage file. This is important
+    # as "coverage combine" will combine all coverage files that match .coverage.*.
+    # The parameters.post_tests_steps might also produce coeverage files
+
     env:
       # Tell Pytest that we're running in a CI environment
       CI: 1
-
-      COVERAGE_FILE: '.coverage.tests'
-      # Note that we're hardcoding the name of the coverage file. This is important
-      # as "coverage combine" will combine all coverage files that match .coverage.*.
-      # The parameters.post_tests_steps might also produce coeverage files
 
       ${{ if eq(parameters.os_name, 'Linux') }}:
         # These environment variables need to be set so Linux runs can connect

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -51,12 +51,21 @@ parameters:
   os_versions:
     - name: Windows
       vm_image: windows-2022
+      codecov_download_url: https://uploader.codecov.io/latest/windows/codecov.exe
 
     - name: Linux
       vm_image: ubuntu-22.04
+      codecov_download_url: https://uploader.codecov.io/latest/linux/codecov
 
     - name: macOS
       vm_image: macOS-14
+      codecov_download_url: https://uploader.codecov.io/v0.7.3/macos/codecov
+      # macOS & codecov note:
+      # In Nov 2024 (SG-36700), we pinned macOS to codecov v0.7.3 because the
+      # macOS-14 Azure Pipelines agent is Intel (x86_64), but Codecov started
+      # shipping arm64-only binaries.
+      # When we will change the macOs image to a arm64 arch, we can use the
+      # "latest" version again.
 
 jobs:
   - ${{ if eq( parameters.has_unit_tests, true ) }}:
@@ -66,6 +75,7 @@ jobs:
           parameters:
             os_name: ${{ os_version.name }}
             image_name: ${{ os_version.vm_image }}
+            codecov_download_url: ${{ os_version.codecov_download_url }}
             python_version: ${{ platform.python_version }}
             qt_wrapper: ${{ platform.qt_wrapper }}
 

--- a/internal/run-tests.yml
+++ b/internal/run-tests.yml
@@ -73,11 +73,11 @@ jobs:
       - ${{ each platform in parameters.vfx_reference_platform_versions }}:
         - template: run-tests-with.yml
           parameters:
-            os_name: ${{ os_version.name }}
-            image_name: ${{ os_version.vm_image }}
             codecov_download_url: ${{ os_version.codecov_download_url }}
+            os_name: ${{ os_version.name }}
             python_version: ${{ platform.python_version }}
             qt_wrapper: ${{ platform.qt_wrapper }}
+            vm_image: ${{ os_version.vm_image }}
 
             # pass through all parameters
             extra_test_dependencies: ${{ parameters.extra_test_dependencies }}


### PR DESCRIPTION
Improve Test Results and Code Coverage reports. Make sure they are properly passed to Azure Pipelines and Codecov.io


Align with other repositories:

- shotgunsoftware/python-api#439
- shotgunsoftware/sg-jira-bridge#103

Implemented by:

- shotgunsoftware/shotgunEvents#101
- shotgunsoftware/tk-core#1082
- shotgunsoftware/tk-framework-desktopserver#308


# Azure Pipeline CI Improvements

- Define job parameter in the "formal" form without a default value to make sure CI fails if the parameters are not provided
- Attempt to make the playbook easier to read
- Simplify the code coverage upload mechanism to [codecov.io](https://about.codecov.io/)
- Drop [pytest-azurepipeline](https://pypi.org/project/pytest-azurepipelines/)
   - This package was prviously used to automatically upload test report and code coverage to Azure Pipelines which is very convenient.
   - Unfortunately, the package does not seem to be maintained anymore. And it is using outdated versions the [PublishTestResults](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/publish-test-results-v2) and [PublishCodeCoverageResults](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/publish-code-coverage-results-v2) Azure Pipeline  tasks.
- Ensure all test results and code coverage are combine and send
    - tk-core and tk-framework-desktopserver have additional tests runnings which produce result and coverage files.
