### PR TITLE
SG-43246 Fix Windows CI broken by involving tests of siblings' repo

### DIFF
--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -187,7 +187,7 @@ jobs:
           --cov \
           --durations=0 \
           --nunit-xml=test-results-main.xml \
-          --verbose \
+          --verbose
     env:
       CI: 1
       # Tell Pytest that we're running in a CI environment


### PR DESCRIPTION
## Issue                                                                                        
                                                                                                  
  Windows CI fails on repos consuming `tk-ci-tools` (e.g. `tk-multi-workfiles2`, `tk-nuke`) -     
  pytest collects tests from sibling-cloned dependency repos:                                     
```                                                                                               
  ERROR ..\tk-framework-qtwidgets\tests\filtering\test_filter_definition.py                       
  ERROR ..\tk-framework-shotgunutils\tests\bg_task_manager\test_background_task_manager.py        
  ...                                                                                             
  !!!!!!!!!!!!!!!!!! Interrupted: 16 errors during collection !!!!!!!!!!!!!!!!!!!
```                                                                                              
  Linux and macOS are unaffected.
                                                                                                  
  ## Root Cause   
                                                                                                  
  Stray trailing `\` on the final line of the pytest command in `internal/run-tests-with.yml`     
  (introduced in #73):
                                                                                                  
  ```yaml         
  script: |
    python -m pytest \
      tests \
      ...
      --verbose \          ← trailing backslash on last line
  ```                                                                                                
  Bash@3 writes the inline script with the host OS's line endings:
                                                                                                  
  - Linux/macOS (LF): \<LF><EOF> is harmlessly discarded.                                         
  - Windows (CRLF): \<CR> is parsed as an escaped literal carriage return, corrupting pytest's
  args. Its rootdir falls back to the parent directory.                                           
                  
  Since clone-repositories.yml clones dependencies as siblings (../tk-core, ../tk-framework-*),   
  pytest then collects every sibling repo's tests.
                                                                                                  
## Fix
  Remove the trailing \ on the final line.

## Test Plan
- [x]  CI turn green for impacted repos

       