### PR TITLE
SG-43835 Show git diff when code style validation fails

### DIFF
--- a/internal/code-style-validation.yml
+++ b/internal/code-style-validation.yml
@@ -36,6 +36,10 @@ jobs:
   - bash: pre-commit run --all
     displayName: Validate code
 
+  - bash: git diff
+    displayName: Show formatting diff
+    condition: failed()
+
   - script: |
       build_sphinx_docs="true"
       [ -d "$(Build.SourcesDirectory)/docs" ] || build_sphinx_docs="false"

--- a/internal/code-style-validation.yml
+++ b/internal/code-style-validation.yml
@@ -37,7 +37,7 @@ jobs:
     displayName: Validate code
 
   - bash: git diff
-    displayName: Show formatting diff
+    displayName: "VIOLATIONS: Files that need reformatting (run pre-commit locally to fix)"
     condition: failed()
 
   - script: |


### PR DESCRIPTION
## Summary

Add a `git diff` step after `pre-commit run --all` that only runs on failure. When pre-commit reformats files and exits non-zero, the diff is now visible directly in the CI logs, making it clear exactly what needs to be fixed.

## Test plan

- [ ] Trigger a PR with a black formatting violation and confirm the diff appears in the Azure Pipelines logs under "Show formatting diff"
