### PR TITLE
SG-44731 Fetch git-lfs content during Azure Pipelines checkout

### DIFF
--- a/internal/clone-repositories.yml
+++ b/internal/clone-repositories.yml
@@ -24,12 +24,3 @@ steps:
      displayName: Clone ${{ repo.name }}(${{ coalesce(repo.ref, 'master') }})
      # Allows us to easily skip when cloning tk-core inside the tk-core repo.
      condition: ne(variables['Build.DefinitionName'], '${{ repo.name }}')
-
-
-  #  - checkout: ${{ repo.name }}
-  #    displayName: Clone ${{ repo.name }}(${{ coalesce(repo.ref, 'master') }})
-  #    lfs: true
-  #   # Explicit checkout step in order to retrieve LFS entities. Otherwise, Azure
-  #   # Pipelines does not retrieve LFS
-  #     # Allows us to easily skip when cloning tk-core inside the tk-core repo.
-  #    condition: ne(variables['Build.DefinitionName'], '${{ repo.name }}')

--- a/internal/clone-repositories.yml
+++ b/internal/clone-repositories.yml
@@ -24,3 +24,12 @@ steps:
      displayName: Clone ${{ repo.name }}(${{ coalesce(repo.ref, 'master') }})
      # Allows us to easily skip when cloning tk-core inside the tk-core repo.
      condition: ne(variables['Build.DefinitionName'], '${{ repo.name }}')
+
+
+  #  - checkout: ${{ repo.name }}
+  #    displayName: Clone ${{ repo.name }}(${{ coalesce(repo.ref, 'master') }})
+  #    lfs: true
+  #   # Explicit checkout step in order to retrieve LFS entities. Otherwise, Azure
+  #   # Pipelines does not retrieve LFS
+  #     # Allows us to easily skip when cloning tk-core inside the tk-core repo.
+  #    condition: ne(variables['Build.DefinitionName'], '${{ repo.name }}')

--- a/internal/code-style-validation.yml
+++ b/internal/code-style-validation.yml
@@ -67,6 +67,12 @@ jobs:
     vmImage: ubuntu-latest
 
   steps:
+  - checkout: self
+    displayName: Git Checkout
+    lfs: true
+    # Explicit checkout step in order to retrieve LFS entities. Otherwise, Azure
+    # Pipelines does not retrieve LFS
+
   - task: UsePythonVersion@0
     displayName: Use Python 3.10
     inputs:

--- a/internal/release.yml
+++ b/internal/release.yml
@@ -23,6 +23,12 @@ jobs:
   pool:
     vmImage: ubuntu-latest
   steps:
+    - checkout: self
+      displayName: Git Checkout
+      lfs: true
+      # Explicit checkout step in order to retrieve LFS entities. Otherwise, Azure
+      # Pipelines does not retrieve LFS
+
     # Switch to the right Python Version.
     - task: UsePythonVersion@0
       inputs:

--- a/internal/run-tests-with.yml
+++ b/internal/run-tests-with.yml
@@ -81,6 +81,12 @@ jobs:
     vmImage: ${{ parameters.vm_image }}
   steps:
 
+  - checkout: self
+    displayName: Git Checkout
+    lfs: true
+    # Explicit checkout step in order to retrieve LFS entities. Otherwise, Azure
+    # Pipelines does not retrieve LFS
+
   # Switch to the right Python Version.
   - task: UsePythonVersion@0
     displayName: Use Python ${{ parameters.python_version }}


### PR DESCRIPTION
## Problem

Azure Pipelines does not retrieve Git LFS content by default on a checkout, even for repos that have LFS-tracked files. Jobs that read those files (e.g. Sphinx doc generation, App Store release/test jobs) could silently work with pointer text instead of real content.

## Fix

Add an explicit `checkout: self` step with `lfs: true` before any other step, in the three pipeline templates that checkout the repository being built: `code-style-validation.yml`, `release.yml`, `run-tests-with.yml`.

## Testing

- Reviewed the diff against `origin/master`: only these 3 files change, each gets the same `checkout: self` / `lfs: true` step, matching the existing indentation style of that file.
